### PR TITLE
fix(demo): fix play/pause icons, add eur and gbp currency

### DIFF
--- a/projects/demo/src/modules/directives/media/examples/2/index.ts
+++ b/projects/demo/src/modules/directives/media/examples/2/index.ts
@@ -15,7 +15,7 @@ export class TuiMediaExample2 {
     paused = true;
 
     get icon(): string {
-        return this.paused ? 'tuiIconPlay2Large' : 'tuiIconPause2Large';
+        return this.paused ? 'tuiIconPlayLarge' : 'tuiIconPauseLarge';
     }
 
     getTime(time: number): string {

--- a/projects/demo/src/modules/directives/media/examples/3/index.ts
+++ b/projects/demo/src/modules/directives/media/examples/3/index.ts
@@ -13,7 +13,7 @@ export class TuiMediaExample3 {
     paused = true;
 
     get icon(): string {
-        return this.paused ? 'tuiIconPlay2Large' : 'tuiIconPause2Large';
+        return this.paused ? 'tuiIconPlayLarge' : 'tuiIconPauseLarge';
     }
 
     toggleState() {

--- a/projects/demo/src/modules/utils/format/examples/3/index.ts
+++ b/projects/demo/src/modules/utils/format/examples/3/index.ts
@@ -12,7 +12,7 @@ import {encapsulation} from '../../../../../view-encapsulation';
     encapsulation,
 })
 export class TuiFormatExample3 {
-    readonly items = ['USD', 'RUB', '643', 'KZT', '051', 'KRW', 'CHF'];
+    readonly items = ['USD', 'RUB', '643', 'KZT', '051', 'KRW', 'CHF', 'EUR', 'GBP'];
 
     parametersForm = new FormGroup({
         currency: new FormControl(null),


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [ ] Feature
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The documentation used "tuiIconPlay2Large" and "tuiIconPause2Large" as the play/pause icons, which do not exist.

Issue Number: N/A

## What is the new behavior?
The correct icons will be used "tuiIconPlayLarge" and "tuiIconPauseLarge"

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

I also added EUR and GBP to the currency Example