### PR TITLE
feat(checkbox): make checkboxes react to new height variables

### DIFF
--- a/projects/core/components/primitive-checkbox/primitive-checkbox.component.ts
+++ b/projects/core/components/primitive-checkbox/primitive-checkbox.component.ts
@@ -65,10 +65,10 @@ export class TuiPrimitiveCheckboxComponent {
     }
 
     get iconCheck(): string {
-        return this.size === 'm' ? 'tuiIconCheck' : 'tuiIconCheckLarge';
+        return this.size === 'l' ? 'tuiIconCheckLarge' : 'tuiIconCheck';
     }
 
     get iconIndeterminate(): string {
-        return this.size === 'm' ? 'tuiIconMinus' : 'tuiIconMinusLarge';
+        return this.size === 'l' ? 'tuiIconMinusLarge' : 'tuiIconMinus';
     }
 }

--- a/projects/core/components/primitive-checkbox/primitive-checkbox.style.less
+++ b/projects/core/components/primitive-checkbox/primitive-checkbox.style.less
@@ -1,22 +1,25 @@
 @import '../../styles/taiga-ui-local.less';
 
-@sizeM: 16px;
-@sizeL: 24px;
-
 :host {
     display: block;
     border-radius: 8px;
     font-size: 0;
 
+    &[data-tui-host-size='s'] {
+        width: calc(var(--tui-height-s) / 2);
+        height: calc(var(--tui-height-s) / 2);
+        border-radius: 4px;
+    }
+
     &[data-tui-host-size='m'] {
-        width: @sizeM;
-        height: @sizeM;
+        width: calc(var(--tui-height-m) / 2);
+        height: calc(var(--tui-height-m) / 2);
         border-radius: 4px;
     }
 
     &[data-tui-host-size='l'] {
-        width: @sizeL;
-        height: @sizeL;
+        width: calc(var(--tui-height-l) / 2);
+        height: calc(var(--tui-height-l) / 2);
     }
 }
 

--- a/projects/demo/src/modules/components/checkbox-labeled/checkbox-labeled.component.ts
+++ b/projects/demo/src/modules/components/checkbox-labeled/checkbox-labeled.component.ts
@@ -5,13 +5,16 @@ import {default as example1Ts} from '!!raw-loader!./examples/1/index.ts';
 import {default as example2Html} from '!!raw-loader!./examples/2/index.html';
 import {default as example2Ts} from '!!raw-loader!./examples/2/index.ts';
 
+import {default as example3Html} from '!!raw-loader!./examples/3/index.html';
+import {default as example3Ts} from '!!raw-loader!./examples/3/index.ts';
+
 import {default as exampleDeclareForm} from '!!raw-loader!./examples/import/declare-form.txt';
 import {default as exampleImportModule} from '!!raw-loader!./examples/import/import-module.txt';
 import {default as exampleInsertTemplate} from '!!raw-loader!./examples/import/insert-template.txt';
 
 import {Component, forwardRef, Inject} from '@angular/core';
 import {FormControl, FormGroup} from '@angular/forms';
-import {TuiSizeL} from '@taiga-ui/core';
+import {TuiSizeL, TuiSizeS} from '@taiga-ui/core';
 import {changeDetection} from '../../../change-detection-strategy';
 import {HOW_TO_PATH_RESOLVER} from '../../../how-to-path-resolver';
 import {FrontEndExample} from '../../interfaces/front-end-example';
@@ -45,9 +48,14 @@ export class ExampleTuiCheckboxLabeledComponent extends AbstractExampleTuiReacti
         HTML: example2Html,
     };
 
-    readonly sizeVariants: ReadonlyArray<TuiSizeL> = ['m', 'l'];
+    readonly example3: FrontEndExample = {
+        TypeScript: example3Ts,
+        HTML: example3Html,
+    };
 
-    size: TuiSizeL = this.sizeVariants[0];
+    readonly sizeVariants: ReadonlyArray<TuiSizeS | TuiSizeL> = ['s', 'm', 'l'];
+
+    size: TuiSizeS | TuiSizeL = this.sizeVariants[1];
 
     control = new FormGroup({
         testValue1: new FormControl(false),

--- a/projects/demo/src/modules/components/checkbox-labeled/checkbox-labeled.module.ts
+++ b/projects/demo/src/modules/components/checkbox-labeled/checkbox-labeled.module.ts
@@ -10,6 +10,7 @@ import {InheritedDocumentationModule} from '../abstract/inherited-documentation/
 import {ExampleTuiCheckboxLabeledComponent} from './checkbox-labeled.component';
 import {TuiCheckboxLabeledExample1} from './examples/1';
 import {TuiCheckboxLabeledExample2} from './examples/2';
+import {TuiCheckboxLabeledExample3} from './examples/3';
 
 @NgModule({
     imports: [
@@ -28,6 +29,7 @@ import {TuiCheckboxLabeledExample2} from './examples/2';
         ExampleTuiCheckboxLabeledComponent,
         TuiCheckboxLabeledExample1,
         TuiCheckboxLabeledExample2,
+        TuiCheckboxLabeledExample3,
     ],
     exports: [ExampleTuiCheckboxLabeledComponent],
 })

--- a/projects/demo/src/modules/components/checkbox-labeled/checkbox-labeled.template.html
+++ b/projects/demo/src/modules/components/checkbox-labeled/checkbox-labeled.template.html
@@ -25,6 +25,15 @@
         >
             <tui-checkbox-labeled-example-2></tui-checkbox-labeled-example-2>
         </tui-doc-example>
+
+        <tui-doc-example
+            id="small"
+            i18n-heading
+            heading="Small size"
+            [content]="example3"
+        >
+            <tui-checkbox-labeled-example-3></tui-checkbox-labeled-example-3>
+        </tui-doc-example>
     </ng-template>
 
     <ng-template pageTab>

--- a/projects/demo/src/modules/components/checkbox-labeled/examples/3/index.html
+++ b/projects/demo/src/modules/components/checkbox-labeled/examples/3/index.html
@@ -1,0 +1,21 @@
+<form [formGroup]="testForm">
+    <tui-checkbox-labeled i18n formControlName="testValue1" size="s">
+        An option
+    </tui-checkbox-labeled>
+    <tui-checkbox-labeled
+        i18n
+        class="tui-space_top-5"
+        formControlName="testValue2"
+        size="s"
+    >
+        An alternative one
+    </tui-checkbox-labeled>
+    <tui-checkbox-labeled
+        i18n
+        class="tui-space_top-5"
+        formControlName="testValue3"
+        size="s"
+    >
+        Other
+    </tui-checkbox-labeled>
+</form>

--- a/projects/demo/src/modules/components/checkbox-labeled/examples/3/index.ts
+++ b/projects/demo/src/modules/components/checkbox-labeled/examples/3/index.ts
@@ -1,0 +1,18 @@
+import {Component} from '@angular/core';
+import {FormControl, FormGroup} from '@angular/forms';
+import {changeDetection} from '../../../../../change-detection-strategy';
+import {encapsulation} from '../../../../../view-encapsulation';
+
+@Component({
+    selector: 'tui-checkbox-labeled-example-3',
+    templateUrl: './index.html',
+    changeDetection,
+    encapsulation,
+})
+export class TuiCheckboxLabeledExample3 {
+    testForm = new FormGroup({
+        testValue1: new FormControl(true),
+        testValue2: new FormControl(false),
+        testValue3: new FormControl(false),
+    });
+}

--- a/projects/demo/src/modules/components/checkbox/checkbox.component.ts
+++ b/projects/demo/src/modules/components/checkbox/checkbox.component.ts
@@ -4,13 +4,16 @@ import {default as example1Ts} from '!!raw-loader!./examples/1/index.ts';
 import {default as example2Html} from '!!raw-loader!./examples/2/index.html';
 import {default as example2Ts} from '!!raw-loader!./examples/2/index.ts';
 
+import {default as example3Html} from '!!raw-loader!./examples/3/index.html';
+import {default as example3Ts} from '!!raw-loader!./examples/3/index.ts';
+
 import {default as exampleDeclareForm} from '!!raw-loader!./examples/import/declare-form.txt';
 import {default as exampleImportModule} from '!!raw-loader!./examples/import/import-module.txt';
 import {default as exampleInsertTemplate} from '!!raw-loader!./examples/import/insert-template.txt';
 
 import {Component, forwardRef, Inject} from '@angular/core';
 import {FormControl, FormGroup} from '@angular/forms';
-import {TuiSizeL} from '@taiga-ui/core';
+import {TuiSizeL, TuiSizeS} from '@taiga-ui/core';
 import {changeDetection} from '../../../change-detection-strategy';
 import {HOW_TO_PATH_RESOLVER} from '../../../how-to-path-resolver';
 import {FrontEndExample} from '../../interfaces/front-end-example';
@@ -43,9 +46,14 @@ export class ExampleTuiCheckboxComponent extends AbstractExampleTuiReactiveField
         HTML: example2Html,
     };
 
-    readonly sizeVariants: ReadonlyArray<TuiSizeL> = ['m', 'l'];
+    readonly example3: FrontEndExample = {
+        TypeScript: example3Ts,
+        HTML: example3Html,
+    };
 
-    size: TuiSizeL = this.sizeVariants[0];
+    readonly sizeVariants: ReadonlyArray<TuiSizeS | TuiSizeL> = ['s', 'm', 'l'];
+
+    size: TuiSizeS | TuiSizeL = this.sizeVariants[1];
 
     readonly control = new FormGroup({
         testValue1: new FormControl(false),

--- a/projects/demo/src/modules/components/checkbox/checkbox.module.ts
+++ b/projects/demo/src/modules/components/checkbox/checkbox.module.ts
@@ -10,6 +10,7 @@ import {InheritedDocumentationModule} from '../abstract/inherited-documentation/
 import {ExampleTuiCheckboxComponent} from './checkbox.component';
 import {TuiCheckboxExample1} from './examples/1';
 import {TuiCheckboxExample2} from './examples/2';
+import {TuiCheckboxExample3} from './examples/3';
 
 @NgModule({
     imports: [
@@ -24,7 +25,12 @@ import {TuiCheckboxExample2} from './examples/2';
         InheritedDocumentationModule,
         RouterModule.forChild(generateRoutes(ExampleTuiCheckboxComponent)),
     ],
-    declarations: [ExampleTuiCheckboxComponent, TuiCheckboxExample1, TuiCheckboxExample2],
+    declarations: [
+        ExampleTuiCheckboxComponent,
+        TuiCheckboxExample1,
+        TuiCheckboxExample2,
+        TuiCheckboxExample3,
+    ],
     exports: [ExampleTuiCheckboxComponent],
 })
 export class ExampleTuiCheckboxModule {}

--- a/projects/demo/src/modules/components/checkbox/checkbox.template.html
+++ b/projects/demo/src/modules/components/checkbox/checkbox.template.html
@@ -28,6 +28,15 @@
         >
             <tui-checkbox-example-2></tui-checkbox-example-2>
         </tui-doc-example>
+
+        <tui-doc-example
+            id="small"
+            i18n-heading
+            heading="Small size"
+            [content]="example3"
+        >
+            <tui-checkbox-example-3></tui-checkbox-example-3>
+        </tui-doc-example>
     </ng-template>
 
     <ng-template pageTab>
@@ -81,7 +90,7 @@
                 i18n
                 documentationPropertyName="size"
                 documentationPropertyMode="input"
-                documentationPropertyType="TuiSizeL"
+                documentationPropertyType="TuiSizeS | TuiSizeL"
                 [documentationPropertyValues]="sizeVariants"
                 [(documentationPropertyValue)]="size"
             >

--- a/projects/demo/src/modules/components/checkbox/examples/3/index.html
+++ b/projects/demo/src/modules/components/checkbox/examples/3/index.html
@@ -1,0 +1,24 @@
+<form [formGroup]="testForm">
+    <tui-checkbox
+        formControlName="testValue1"
+        class="tui-space_bottom-3"
+        size="s"
+    >
+    </tui-checkbox>
+
+    <tui-checkbox
+        formControlName="testValue2"
+        class="tui-space_bottom-3"
+        size="s"
+    >
+    </tui-checkbox>
+
+    <tui-checkbox
+        formControlName="testValue3"
+        class="tui-space_bottom-3"
+        size="s"
+    >
+    </tui-checkbox>
+
+    <tui-checkbox formControlName="testValue4" size="s"> </tui-checkbox>
+</form>

--- a/projects/demo/src/modules/components/checkbox/examples/3/index.ts
+++ b/projects/demo/src/modules/components/checkbox/examples/3/index.ts
@@ -1,0 +1,19 @@
+import {Component} from '@angular/core';
+import {FormControl, FormGroup} from '@angular/forms';
+import {changeDetection} from '../../../../../change-detection-strategy';
+import {encapsulation} from '../../../../../view-encapsulation';
+
+@Component({
+    selector: 'tui-checkbox-example-3',
+    templateUrl: './index.html',
+    changeDetection,
+    encapsulation,
+})
+export class TuiCheckboxExample3 {
+    testForm = new FormGroup({
+        testValue1: new FormControl(true),
+        testValue2: new FormControl(false),
+        testValue3: new FormControl({value: true, disabled: true}),
+        testValue4: new FormControl({value: false, disabled: true}),
+    });
+}

--- a/projects/kit/components/checkbox-block/checkbox-block.component.ts
+++ b/projects/kit/components/checkbox-block/checkbox-block.component.ts
@@ -56,7 +56,7 @@ export class TuiCheckboxBlockComponent
     @Input()
     @HostBinding('attr.data-tui-host-size')
     @tuiDefaultProp()
-    size: TuiSizeS | TuiSizeL = 'l';
+    size: TuiSizeS | TuiSizeL = 'm';
 
     @ViewChild(TuiCheckboxComponent)
     private checkbox?: TuiCheckboxComponent;
@@ -83,8 +83,8 @@ export class TuiCheckboxBlockComponent
         return this.value !== false && this.hideCheckbox;
     }
 
-    get checkboxSize(): TuiSizeL {
-        return this.size === 'l' ? 'l' : 'm';
+    get checkboxSize(): TuiSizeS | TuiSizeL {
+        return this.size;
     }
 
     get focused(): boolean {

--- a/projects/kit/components/checkbox-block/checkbox-block.style.less
+++ b/projects/kit/components/checkbox-block/checkbox-block.style.less
@@ -46,11 +46,11 @@
     }
 
     :host[data-tui-host-size='m'] & {
-        min-height: var(--tui-height-l);
+        min-height: var(--tui-height-m);
     }
 
     :host[data-tui-host-size='l'] & {
-        min-height: var(--tui-height-xl);
+        min-height: var(--tui-height-l);
     }
 }
 
@@ -58,69 +58,55 @@
     display: flex;
     align-items: center;
     min-height: inherit;
+    padding-left: calc(var(--tui-height-m) / 2);
+    padding-right: calc(var(--tui-height-m) / 2);
 
     :host[data-tui-host-align='right'] & {
         flex-direction: row-reverse;
     }
 
     :host[data-tui-host-size='s'] & {
-        padding: 0 16px 0 8px;
-    }
-
-    :host[data-tui-host-size='s'][data-tui-host-align='right'] & {
-        padding: 0 8px 0 16px;
-    }
-
-    :host[data-tui-host-size='s']._hidden_checkbox & {
-        padding: 0 16px;
-    }
-
-    :host[data-tui-host-size='m'] & {
-        padding: 0 16px 0 12px;
-    }
-
-    :host[data-tui-host-size='m'][data-tui-host-align='right'] & {
-        padding: 0 12px 0 16px;
-    }
-
-    :host[data-tui-host-size='m']._hidden_checkbox & {
-        padding: 0 24px;
+        padding-left: calc(var(--tui-height-s) / 2);
+        padding-right: calc(var(--tui-height-s) / 2);
     }
 
     :host[data-tui-host-size='l'] & {
-        padding: 0 16px;
-    }
-
-    :host[data-tui-host-size='l']._hidden_checkbox & {
-        padding: 0 36px;
+        padding-left: calc(var(--tui-height-l) / 2);
+        padding-right: calc(var(--tui-height-l) / 2);
     }
 }
 
 .view {
-    margin-top: 12px;
-    margin-right: 12px;
+    margin-top: calc(var(--tui-height-m) / 4);
+    margin-left: calc(var(--tui-height-m) / -4);
+    margin-right: calc(var(--tui-height-m) / 4);
     align-self: flex-start;
 
     :host[data-tui-host-align='right'] & {
-        margin-left: 12px;
-        margin-right: 0;
+        margin-left: calc(var(--tui-height-m) / 4);
+        margin-right: calc(var(--tui-height-m) / -4);
     }
 
     :host[data-tui-host-size='s'] & {
-        margin-top: 8px;
-        margin-right: 8px;
+        margin-top: calc(var(--tui-height-s) / 4);
+        margin-left: calc(var(--tui-height-s) / -4);
+        margin-right: calc(var(--tui-height-s) / 4);
     }
 
     :host[data-tui-host-size='s'][data-tui-host-align='right'] & {
-        margin-left: 8px;
-    }
-
-    :host[data-tui-host-size='m'] & {
-        margin-top: 14px;
+        margin-left: calc(var(--tui-height-s) / 4);
+        margin-right: calc(var(--tui-height-s) / -4);
     }
 
     :host[data-tui-host-size='l'] & {
-        margin-top: 16px;
+        margin-top: calc(var(--tui-height-l) / 4);
+        margin-left: calc(var(--tui-height-l) / -4);
+        margin-right: calc(var(--tui-height-l) / 4);
+    }
+
+    :host[data-tui-host-size='l'][data-tui-host-align='right'] & {
+        margin-left: calc(var(--tui-height-l) / 4);
+        margin-right: calc(var(--tui-height-l) / -4);
     }
 
     :host._hidden_checkbox & {

--- a/projects/kit/components/checkbox-labeled/checkbox-labeled.style.less
+++ b/projects/kit/components/checkbox-labeled/checkbox-labeled.style.less
@@ -26,12 +26,17 @@
 }
 
 .content {
-    .text-body-s(2);
+    .text-body-s();
     word-wrap: break-word;
     min-width: 0;
 
     &_disabled {
         opacity: var(--tui-disabled-opacity);
+    }
+
+    :host[data-tui-host-size='s'] & {
+        .text-body-s(2);
+        margin-left: 8px;
     }
 
     :host[data-tui-host-size='m'] & {

--- a/projects/kit/components/checkbox/checkbox.component.ts
+++ b/projects/kit/components/checkbox/checkbox.component.ts
@@ -19,7 +19,7 @@ import {
     tuiDefaultProp,
     TuiFocusableElementAccessor,
 } from '@taiga-ui/cdk';
-import {TuiSizeL} from '@taiga-ui/core';
+import {TuiSizeL, TuiSizeS} from '@taiga-ui/core';
 
 @Component({
     selector: 'tui-checkbox',
@@ -39,7 +39,7 @@ export class TuiCheckboxComponent
     @Input()
     @HostBinding('attr.data-tui-host-size')
     @tuiDefaultProp()
-    size: TuiSizeL = 'm';
+    size: TuiSizeS | TuiSizeL = 'm';
 
     @ViewChild('focusableElement')
     private readonly focusableElement?: ElementRef<HTMLInputElement>;

--- a/projects/kit/components/checkbox/checkbox.style.less
+++ b/projects/kit/components/checkbox/checkbox.style.less
@@ -1,22 +1,24 @@
 @import 'taiga-ui-local';
 
-@sizeM: 16px;
-@sizeL: 24px;
-
 :host {
     .text-basic();
     position: relative;
     display: block;
     flex-shrink: 0;
 
+    &[data-tui-host-size='s'] {
+        width: calc(var(--tui-height-s) / 2);
+        height: calc(var(--tui-height-s) / 2);
+    }
+
     &[data-tui-host-size='m'] {
-        width: @sizeM;
-        height: @sizeM;
+        width: calc(var(--tui-height-m) / 2);
+        height: calc(var(--tui-height-m) / 2);
     }
 
     &[data-tui-host-size='l'] {
-        width: @sizeL;
-        height: @sizeL;
+        width: calc(var(--tui-height-l) / 2);
+        height: calc(var(--tui-height-l) / 2);
     }
 }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [x] Feature
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Other... Please describe:

## What is the current behavior?

Checkboxes currently do not react to the newly introduced CSS height properties.

## What is the new behavior?

Checkboxes now react to CSS height properties. They are exactly half in size of the respective variable value. A new size has been added to keep a 16px size variance. One problem is, that the L variance is now 22px heigh (and not 24px) and does not fit into the 4px base grid. This is due to the respective height variable being 44px instead of 48px. I think it would make sense to increase this value, but I can't oversee the impact, that such a change would have. Maybe this PR is a good base for discussions.

## Does this PR introduce a breaking change?

-   [x] Yes
-   [ ] No

Size L is now 22px instead of 24px.

## Other information

A similar approach could be taken for toggles and radio buttons.