### PR TITLE
feat(format): number formatting supports custom thousands separator

### DIFF
--- a/projects/core/utils/format/capitalize.ts
+++ b/projects/core/utils/format/capitalize.ts
@@ -1,6 +1,9 @@
 /**
- * Преобразовывает строку, заменяя её на нижний регистр и делая первую букву каждого слова в верхнем регистре
- * @param value строка
+ * Capitalizes a given string, replacing it with a lowercase string and making
+ * the first letter of each word uppercase.
+ *
+ * @param value the input string
+ * @return the capitalized string
  */
 export function capitalize(value: string): string {
     return value.toLowerCase().replace(/(?:^|\s)\S/g, char => char.toUpperCase());

--- a/projects/core/utils/format/format-number.ts
+++ b/projects/core/utils/format/format-number.ts
@@ -4,15 +4,17 @@ import {CHAR_NO_BREAK_SPACE} from '@taiga-ui/cdk';
  * Formats number adding thousand separators and correct decimal separator
  * padding decimal part with zeroes to given length
  *
- * @param value number
- * @param decimalSeparator
+ * @param value the input number
  * @param decimalLimit number of digits of decimal part, null to keep untouched
- * @return formatted string
+ * @param decimalSeparator separator between the integer and the decimal part
+ * @param thousandSeparator separator between thousands
+ * @return the formatted string
  */
 export function formatNumber(
     value: number,
     decimalLimit: number | null = null,
     decimalSeparator: string = ',',
+    thousandSeparator: string = CHAR_NO_BREAK_SPACE,
 ): string {
     const integerPartString = Math.floor(Math.abs(value)).toString();
     const fractionPartString = value.toString().split('.')[1] || '';
@@ -27,7 +29,7 @@ export function formatNumber(
 
     for (let i = 1; i < integerPartString.length; i++) {
         if (i % 3 === remainder && integerPartString.length > 3) {
-            result += CHAR_NO_BREAK_SPACE;
+            result += thousandSeparator;
         }
 
         result += integerPartString.charAt(i);

--- a/projects/core/utils/format/format-phone.ts
+++ b/projects/core/utils/format/format-phone.ts
@@ -1,9 +1,11 @@
 /**
- * Форматирует строку с телефоном формата +7XXXXXXXXXX или XXXXXXXXXX, добавляя скобки и дефисы
- * @param value строка для форматирования
- * @param countryCode телефонный код страны
- * @param phoneMask маска телефонного номера
- * @return отформатированная строка телефона вида +7 XXX XXX-XX-XX
+ * Formats a string with the phone format +7XXXXXXXXXXXX or XXXXXXXXXXXX,
+ * adding parentheses and hyphens.
+ *
+ * @param value the input string
+ * @param countryCode a country code
+ * @param phoneMask a phone number mask
+ * @return the formatted phone string of the form +7 XXX XXX-XX-XX
  */
 export function formatPhone(
     value: string,

--- a/projects/core/utils/format/pluralize.ts
+++ b/projects/core/utils/format/pluralize.ts
@@ -5,6 +5,8 @@ import {TuiPluralize} from '@taiga-ui/core/types';
  *
  * @param value the input number
  * @param args an array of three plural forms, e.g. ['год', 'года', 'лет']
+ * @deprecated This implementation targets Russian.
+ * Use https://angular.io/api/common/NgPlural for your implementations.
  */
 export function pluralize(value: number, [one, few, many]: TuiPluralize): string {
     const ten = value % 10;

--- a/projects/core/utils/format/pluralize.ts
+++ b/projects/core/utils/format/pluralize.ts
@@ -1,9 +1,10 @@
 import {TuiPluralize} from '@taiga-ui/core/types';
 
 /**
- * Выбирает корректную форму множественного числа для отображения количества
- * @param value число
- * @param args массив из трёх форм множественного числа, например ['год', 'года', 'лет']
+ * Selects the correct plural form to display.
+ *
+ * @param value the input number
+ * @param args an array of three plural forms, e.g. ['год', 'года', 'лет']
  */
 export function pluralize(value: number, [one, few, many]: TuiPluralize): string {
     const ten = value % 10;

--- a/projects/core/utils/format/test/capitalize.spec.ts
+++ b/projects/core/utils/format/test/capitalize.spec.ts
@@ -2,39 +2,37 @@ import {CHAR_NO_BREAK_SPACE} from '@taiga-ui/cdk';
 import {capitalize} from '../capitalize';
 
 describe('Capitalize', () => {
-    it('Делает первую букву слова заглавной', () => {
-        expect(capitalize('бэн')).toBe('Бэн');
+    it('capitalizes the first letter of the word', () => {
+        expect(capitalize('lorem')).toBe('Lorem');
     });
 
-    it('Делает первую букву каждого слова заглавной', () => {
-        expect(capitalize('папаша торк')).toBe('Папаша Торк');
+    it('capitalizes the first letter of each word', () => {
+        expect(capitalize('lorem ipsum')).toBe('Lorem Ipsum');
     });
 
-    it('Делает остальные буквы слова строчными', () => {
-        expect(capitalize('FULL THROTTLE')).toBe('Full Throttle');
+    it('transforms the other letters of a word to lowercase', () => {
+        expect(capitalize('LOREM IPSUM')).toBe('Lorem Ipsum');
     });
 
-    it('Работает для символа неразрывного пробела', () => {
+    it('works for the non-breaking space character', () => {
         expect(
-            capitalize(
-                `тяжёлый${CHAR_NO_BREAK_SPACE}запах${CHAR_NO_BREAK_SPACE}асфальта`,
-            ),
-        ).toBe(`Тяжёлый${CHAR_NO_BREAK_SPACE}Запах${CHAR_NO_BREAK_SPACE}Асфальта`);
+            capitalize(`lorem${CHAR_NO_BREAK_SPACE}ipsum${CHAR_NO_BREAK_SPACE}dolor`),
+        ).toBe(`Lorem${CHAR_NO_BREAK_SPACE}Ipsum${CHAR_NO_BREAK_SPACE}Dolor`);
     });
 
-    it('Слово с дефисом не считается за два слова', () => {
-        expect(capitalize('корлей-моторс')).toBe('Корлей-моторс');
+    it('a hyphen inside the word does not break it into two', () => {
+        expect(capitalize('up-to-date')).toBe('Up-to-date');
     });
 
-    it('Точка внутри слова не разбивает его на два', () => {
+    it('a dot inside the word does not break it into two', () => {
         expect(capitalize('adrian.ripburger')).toBe('Adrian.ripburger');
     });
 
-    it('Запятая внутри слова не разбивает его на два', () => {
+    it('a comma inside the word does not break it into two', () => {
         expect(capitalize('malcolm,corley')).toBe('Malcolm,corley');
     });
 
-    it('Корректно отрабатывает всякую всячину', () => {
+    it('correctly handles all sorts of things', () => {
         expect(
             capitalize(
                 'Добавь тЕст. где 2 предложения: с!Разными №знаками;препинания, ок?',

--- a/projects/core/utils/format/test/format-number.spec.ts
+++ b/projects/core/utils/format/test/format-number.spec.ts
@@ -1,50 +1,54 @@
 import {CHAR_NO_BREAK_SPACE} from '@taiga-ui/cdk';
 import {formatNumber} from '../format-number';
 
-describe('Форматирование числа', () => {
-    it('Вставляет разделитель для чисел > 999', () => {
+describe('Number formatting', () => {
+    it('inserts delimiter for numbers > 999', () => {
         expect(formatNumber(1000)).toBe(`1${CHAR_NO_BREAK_SPACE}000`);
     });
 
-    it('Корректно вставляет разделитель для одного старшего порядка', () => {
+    it('correctly inserts the separator for one higher order', () => {
         expect(formatNumber(1234567)).toBe(
             `1${CHAR_NO_BREAK_SPACE}234${CHAR_NO_BREAK_SPACE}567`,
         );
     });
 
-    it('Корректно вставляет разделитель для двух старших порядков', () => {
+    it('correctly inserts the separator for the two higher orders', () => {
         expect(formatNumber(12345678)).toBe(
             `12${CHAR_NO_BREAK_SPACE}345${CHAR_NO_BREAK_SPACE}678`,
         );
     });
 
-    it('Корректно вставляет разделитель для трёх старших порядков', () => {
+    it('correctly inserts the separator for the three higher orders', () => {
         expect(formatNumber(123456789)).toBe(
             `123${CHAR_NO_BREAK_SPACE}456${CHAR_NO_BREAK_SPACE}789`,
         );
     });
 
-    it('Сохраняет минус', () => {
+    it('keeps minus', () => {
         expect(formatNumber(-123)).toBe('-123');
     });
 
-    it('Сохраняет дробную часть', () => {
+    it('preserves the fractional part', () => {
         expect(formatNumber(1.234)).toBe('1,234');
     });
 
-    it('Добивает нулями дробную часть до заданной величины', () => {
+    it('finishes the fractional part with zeros to a given value', () => {
         expect(formatNumber(123, 2)).toBe('123,00');
     });
 
-    it('Отбрасывает лишнюю дробную часть', () => {
+    it('discards the extra fractional part', () => {
         expect(formatNumber(1.234, 2)).toBe('1,23');
     });
 
-    it('Отбрасывает дробную часть совсем', () => {
+    it('discards the fractional part altogether', () => {
         expect(formatNumber(5.678, 0)).toBe('5');
     });
 
-    it('Принимает кастомный разделитель дробной части', () => {
+    it('accepts custom fractional separator', () => {
         expect(formatNumber(123.45, 2, '.')).toBe('123.45');
+    });
+
+    it('accepts custom thousands separator', () => {
+        expect(formatNumber(12345.67, 2, ',', '.')).toBe('12.345,67');
     });
 });

--- a/projects/core/utils/format/test/format-phone.spec.ts
+++ b/projects/core/utils/format/test/format-phone.spec.ts
@@ -1,25 +1,25 @@
 import {formatPhone} from '../format-phone';
 
-describe('Форматирование телефона', () => {
-    it('Корректно вставляет скобки и дефисы', () => {
+describe('Phone number formatting', () => {
+    it('inserts parentheses and hyphens correctly', () => {
         expect(formatPhone('+78005557778', '+7', '(###) ###-##-##')).toEqual(
             `+7 (800) 555-77-78`,
         );
     });
 
-    it('Корректно работает со строкой без countryCode', () => {
+    it('works correctly with a string without countryCode', () => {
         expect(formatPhone('8005557778', '+7', '(###) ###-##-##')).toBe(
             `+7 (800) 555-77-78`,
         );
     });
 
-    it('Корректно вставляет любые другие символы', () => {
+    it('inserts any other characters correctly', () => {
         expect(formatPhone('+78005557778', '+7', '/###/###_##_##')).toBe(
             `+7 /800/555_77_78`,
         );
     });
 
-    it('returns country code with whitespace if only country code was inputed', () => {
+    it('returns country code with whitespace if only country code is given', () => {
         expect(formatPhone('+7', '+7', '/###/###_##_##')).toBe(`+7 `);
     });
 });

--- a/projects/core/utils/format/test/pluralize.spec.ts
+++ b/projects/core/utils/format/test/pluralize.spec.ts
@@ -4,7 +4,7 @@ function check(value: number, result: string) {
     expect(pluralize(value, ['год', 'года', 'лет'])).toBe(result);
 }
 
-describe('pluralize', () => {
+describe('Pluralize', () => {
     describe('год', () => {
         it('1', () => {
             check(1, 'год');

--- a/projects/core/utils/mask/test/masked-number-string-to-number.spec.ts
+++ b/projects/core/utils/mask/test/masked-number-string-to-number.spec.ts
@@ -1,8 +1,8 @@
 import {CHAR_NO_BREAK_SPACE} from '@taiga-ui/cdk';
 import {maskedNumberStringToNumber} from '../masked-number-string-to-number';
 
-describe('Превращает текстовое значение числа, полученное от маски в число', () => {
-    it('Корректно отрабатывает разделитель', () => {
+describe('Converts the text value of a number obtained from a mask into a number', () => {
+    it('the separator works correctly', () => {
         expect(
             maskedNumberStringToNumber(
                 `12${CHAR_NO_BREAK_SPACE}345${CHAR_NO_BREAK_SPACE}678`,
@@ -10,11 +10,11 @@ describe('Превращает текстовое значение числа, �
         ).toBe(12345678);
     });
 
-    it('Корректно отрабатывает дробную часть', () => {
+    it('correctly handles the fractional part', () => {
         expect(maskedNumberStringToNumber('1,23')).toBe(1.23);
     });
 
-    it('Возвращает NaN, если невозможно перевести строку в число', () => {
+    it('returns NaN if the string cannot be converted to a number', () => {
         expect(maskedNumberStringToNumber('Дичь')).toBeNaN();
     });
 });

--- a/projects/core/utils/mask/test/tui-create-auto-corrected-number-pipe.spec.ts
+++ b/projects/core/utils/mask/test/tui-create-auto-corrected-number-pipe.spec.ts
@@ -14,35 +14,35 @@ function wrapper(
     ) as TuiTextMaskPipeResult).value;
 }
 
-describe('tuiCreateAutoCorrectedNumberPipe возвращает', () => {
-    describe('исходную строку, если она', () => {
-        it('пустая', () => {
+describe('tuiCreateAutoCorrectedNumberPipe returns', () => {
+    describe('the original string if it', () => {
+        it('is blank', () => {
             expect(wrapper('')).toBe('');
         });
 
-        it('если в ней нет запятой, и она не нужна (по умолчанию)', () => {
+        it('does not contain a comma and it is not needed (by default)', () => {
             expect(wrapper('-123')).toBe('-123');
         });
 
-        it('если дробная часть соответствует формату', () => {
+        it('if the fractional part matches the format', () => {
             expect(wrapper('123,45', 2)).toBe('123,45');
         });
 
-        it('если есть точка и символ разделителя — точка', () => {
+        it('if there is a dot and a delimiter character - dot', () => {
             expect(wrapper('123.45', 2, '.')).toBe('123.45');
         });
     });
 
-    describe('исправленную строку, если дробная часть', () => {
-        it('короче заданной', () => {
+    describe('the corrected string if the fractional part is', () => {
+        it('shorter than the given one', () => {
             expect(wrapper('123,00', 4)).toBe('123,0000');
         });
 
-        it('совсем отсутствует, но нужна', () => {
+        it('not available at all, but needed', () => {
             expect(wrapper('123', 2)).toBe('123,00');
         });
 
-        it('совсем отсутствует, но нужна, с разделителем точкой', () => {
+        it('not present at all, but needed, with a dot separator', () => {
             expect(wrapper('123', 2, '.')).toBe('123.00');
         });
     });

--- a/projects/demo/src/modules/utils/format/examples/6/index.html
+++ b/projects/demo/src/modules/utils/format/examples/6/index.html
@@ -1,0 +1,19 @@
+'{{ formattedNumber }}' = formatNumber(value, decimalLimit, decimalSeparator,
+thousandSeparator);
+
+<form [formGroup]="parametersForm">
+    <div class="parameters">
+        <tui-input formControlName="value" class="tui-space_top-2">
+            value
+        </tui-input>
+        <tui-input formControlName="decimalLimit" class="tui-space_top-2">
+            decimalLimit
+        </tui-input>
+        <tui-input formControlName="decimalSeparator" class="tui-space_top-2">
+            decimalSeparator
+        </tui-input>
+        <tui-input formControlName="thousandSeparator" class="tui-space_top-2">
+            thousandSeparator
+        </tui-input>
+    </div>
+</form>

--- a/projects/demo/src/modules/utils/format/examples/6/index.less
+++ b/projects/demo/src/modules/utils/format/examples/6/index.less
@@ -1,0 +1,4 @@
+.parameters {
+    margin-top: 12px;
+    width: 220px;
+}

--- a/projects/demo/src/modules/utils/format/examples/6/index.ts
+++ b/projects/demo/src/modules/utils/format/examples/6/index.ts
@@ -1,0 +1,32 @@
+import {Component} from '@angular/core';
+import {FormControl, FormGroup} from '@angular/forms';
+import {formatNumber} from '@taiga-ui/core';
+import {changeDetection} from '../../../../../change-detection-strategy';
+import {encapsulation} from '../../../../../view-encapsulation';
+
+@Component({
+    selector: 'tui-format-example-6',
+    templateUrl: './index.html',
+    styleUrls: ['./index.less'],
+    changeDetection,
+    encapsulation,
+})
+export class TuiFormatExample6 {
+    parametersForm = new FormGroup({
+        value: new FormControl(123456.789),
+        decimalLimit: new FormControl(2),
+        decimalSeparator: new FormControl('.'),
+        thousandSeparator: new FormControl(' '),
+    });
+
+    get formattedNumber(): string {
+        const {
+            value,
+            decimalLimit,
+            decimalSeparator,
+            thousandSeparator,
+        } = this.parametersForm.value;
+
+        return formatNumber(value, decimalLimit, decimalSeparator, thousandSeparator);
+    }
+}

--- a/projects/demo/src/modules/utils/format/format.component.ts
+++ b/projects/demo/src/modules/utils/format/format.component.ts
@@ -18,6 +18,10 @@ import {default as example5Html} from '!!raw-loader!./examples/5/index.html';
 import {default as example5Less} from '!!raw-loader!./examples/5/index.less';
 import {default as example5Ts} from '!!raw-loader!./examples/5/index.ts';
 
+import {default as example6Html} from '!!raw-loader!./examples/6/index.html';
+import {default as example6Less} from '!!raw-loader!./examples/6/index.less';
+import {default as example6Ts} from '!!raw-loader!./examples/6/index.ts';
+
 import {default as importComponentExample} from '!!raw-loader!./examples/import/import-component.txt';
 
 import {Component} from '@angular/core';
@@ -60,5 +64,11 @@ export class ExampleFormatComponent {
         TypeScript: example5Ts,
         HTML: example5Html,
         LESS: example5Less,
+    };
+
+    readonly example6: FrontEndExample = {
+        TypeScript: example6Ts,
+        HTML: example6Html,
+        LESS: example6Less,
     };
 }

--- a/projects/demo/src/modules/utils/format/format.module.ts
+++ b/projects/demo/src/modules/utils/format/format.module.ts
@@ -15,6 +15,7 @@ import {TuiFormatExample2} from './examples/2';
 import {TuiFormatExample3} from './examples/3';
 import {TuiFormatExample4} from './examples/4';
 import {TuiFormatExample5} from './examples/5';
+import {TuiFormatExample6} from './examples/6';
 import {ExampleFormatComponent} from './format.component';
 
 @NgModule({
@@ -37,6 +38,7 @@ import {ExampleFormatComponent} from './format.component';
         TuiFormatExample3,
         TuiFormatExample4,
         TuiFormatExample5,
+        TuiFormatExample6,
     ],
     exports: [ExampleFormatComponent],
 })

--- a/projects/demo/src/modules/utils/format/format.template.html
+++ b/projects/demo/src/modules/utils/format/format.template.html
@@ -36,7 +36,7 @@
             id="capitalize"
             heading="capitalize"
             i18n-description
-            description="Capitalizes every work in a string"
+            description="Capitalizes every word in a string"
             [content]="example4"
         >
             <tui-format-example-4></tui-format-example-4>
@@ -50,6 +50,16 @@
             [content]="example5"
         >
             <tui-format-example-5></tui-format-example-5>
+        </tui-doc-example>
+
+        <tui-doc-example
+            id="formatNumber"
+            heading="formatNumber"
+            i18n-description
+            description="Formats a number with separators"
+            [content]="example6"
+        >
+            <tui-format-example-6></tui-format-example-6>
         </tui-doc-example>
     </ng-template>
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
-   [x] Tests for the changes have been added (for bug fixes / features)
-   [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [x] Feature
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Other... Please describe:

## What is the current behavior?

The `formatNumber` function does not support custom thousands separator.

## What is the new behavior?

The `formatNumber` function now does support custom thousands separators as last argument. (Example: German uses `,`as decimal separator and `.` as thousands separator)

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

While at it, I translated the formatting tests and added the formatNumber to the docs.