### PR TITLE
fix(kit): fix wrong button height for customized count inputs

### DIFF
--- a/projects/kit/components/input-count/input-count.style.less
+++ b/projects/kit/components/input-count/input-count.style.less
@@ -1,8 +1,5 @@
 @import 'taiga-ui-local';
 
-@padding-medium: 12px;
-@padding-large: 16px;
-
 :host {
     .text-body-s();
     display: flex;
@@ -39,8 +36,8 @@
 
 .button {
     && {
-        width: var(--tui-height-s);
-        height: 21px;
+        width: calc(var(--tui-height-m) * 0.75);
+        height: calc(50% - 1px);
 
         &_plus {
             margin-bottom: 2px;
@@ -52,8 +49,7 @@
         }
 
         :host[data-tui-host-size='l'] & {
-            width: 40px;
-            height: 27px;
+            width: calc(var(--tui-height-l) * 0.75);
         }
     }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [ ] Feature
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Other... Please describe:

## What is the current behavior?

Input height can be adjust using a CSS custom property. However, the height of the plus / minus button is hardcoded and thus does not match the total height of the input if the CSS property is changed. This buttons are misaligned.

## What is the new behavior?

Buttons scale according to CSS custom properties.

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
