### PR TITLE
feat(kit): update tabs scroll position on activeIndex change

### DIFF
--- a/projects/kit/components/tabs/tabs/tabs.component.ts
+++ b/projects/kit/components/tabs/tabs/tabs.component.ts
@@ -138,7 +138,7 @@ export class TuiTabsComponent implements AfterViewChecked {
         moveFocus(tabs.indexOf(current), tabs, step);
     }
 
-    updateScrollPosition(element: HTMLElement) {
+    updateScrollPosition(element?: HTMLElement) {
         if (!element) {
             return;
         }

--- a/projects/kit/components/tabs/tabs/tabs.component.ts
+++ b/projects/kit/components/tabs/tabs/tabs.component.ts
@@ -126,7 +126,7 @@ export class TuiTabsComponent implements AfterViewChecked {
             return;
         }
 
-        this.activeItemIndex = index;
+        this.activeItemIndexSetter = index;
         this.activeItemIndexChange.emit(index);
     }
 

--- a/projects/kit/components/tabs/tabs/tabs.component.ts
+++ b/projects/kit/components/tabs/tabs/tabs.component.ts
@@ -50,9 +50,11 @@ export class TuiTabsComponent implements AfterViewChecked {
     @tuiDefaultProp()
     underline = true;
 
-    @Input()
-    @tuiDefaultProp()
-    activeItemIndex = 0;
+    @Input('activeItemIndex')
+    set activeItemIndexSetter(index: number) {
+        this.activeItemIndex = index;
+        this.updateScrollPosition(this.tabs[index]);
+    }
 
     @Output()
     readonly activeItemIndexChange = new EventEmitter<number>();
@@ -65,6 +67,8 @@ export class TuiTabsComponent implements AfterViewChecked {
 
     @ContentChildren(forwardRef(() => TuiTabComponent))
     private readonly children: QueryList<unknown> = EMPTY_QUERY;
+
+    activeItemIndex = 0;
 
     constructor(
         @Inject(ElementRef) private readonly elementRef: ElementRef<HTMLElement>,
@@ -124,6 +128,20 @@ export class TuiTabsComponent implements AfterViewChecked {
 
         this.activeItemIndex = index;
         this.activeItemIndexChange.emit(index);
+    }
+
+    @HostListener('keydown.arrowRight.prevent', ['$event.target', '1'])
+    @HostListener('keydown.arrowLeft.prevent', ['$event.target', '-1'])
+    onKeyDownArrow(current: HTMLElement, step: number) {
+        const {tabs} = this;
+
+        moveFocus(tabs.indexOf(current), tabs, step);
+    }
+
+    updateScrollPosition(element: HTMLElement) {
+        if (!element) {
+            return;
+        }
 
         const {offsetLeft, offsetWidth} = element;
         const {nativeElement} = this.elementRef;
@@ -139,13 +157,5 @@ export class TuiTabsComponent implements AfterViewChecked {
             nativeElement.scrollLeft =
                 offsetLeft + offsetWidth - nativeElement.offsetWidth;
         }
-    }
-
-    @HostListener('keydown.arrowRight.prevent', ['$event.target', '1'])
-    @HostListener('keydown.arrowLeft.prevent', ['$event.target', '-1'])
-    onKeyDownArrow(current: HTMLElement, step: number) {
-        const {tabs} = this;
-
-        moveFocus(tabs.indexOf(current), tabs, step);
     }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

-   [ ] Bugfix
-   [x] Feature
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Other... Please describe:

## What is the new behavior?

Now tabs will update scroll position on activeIndex change. Previously it worked only after click on tab.

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

