### PR TITLE
fix(kit): prevent input-range from emitting same value on blur

### DIFF
--- a/projects/kit/components/input-range/input-range.component.ts
+++ b/projects/kit/components/input-range/input-range.component.ts
@@ -222,7 +222,10 @@ export class TuiInputRangeComponent
         const value = isNaN(inputValue) ? this.min : this.valueGuard(inputValue);
 
         this.nativeLeft.nativeElement.value = formatNumber(value);
-        this.updateValue([value, this.value[1]]);
+
+        if (value !== this.value[0]) {
+            this.updateValue([value, this.value[1]]);
+        }
     }
 
     onRightFocused(focused: boolean) {
@@ -236,7 +239,10 @@ export class TuiInputRangeComponent
             : this.valueGuard(Math.max(inputValue, this.value[0]));
 
         this.nativeRight.nativeElement.value = formatNumber(value);
-        this.updateValue([this.value[0], value]);
+
+        if (value !== this.value[1]) {
+            this.updateValue([this.value[0], value]);
+        }
     }
 
     protected getFallbackValue(): [number, number] {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [ ] Feature
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Other... Please describe:

## What is the new behavior?

Input-range control won't emit same value on blur.

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No


