### PR TITLE
fix(core): fix sticky behavior for tui-scrollbar content

### DIFF
--- a/projects/core/components/scrollbar/scrollbar.style.less
+++ b/projects/core/components/scrollbar/scrollbar.style.less
@@ -34,4 +34,5 @@
     flex: 1;
     flex-basis: auto;
     width: 100%;
+    height: max-content;
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [ ] Feature
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Other... Please describe:

## What is the current behavior?

Height of scrollable content wrapper match to scrollbar viewport. Breaks sticky once scrolled more than on full height of scrollbar viewport.

Closes #269

## What is the new behavior?

Adds height intrinsic sizing to scrollbar div.content to match real content size. Now height of scrollable content wrapper match to content height.

## Does this PR introduce a breaking change?

-   [x] Yes
-   [ ] No

Change behavior in cases, when content height lower than scrollbar view height - content height makes smaller than before. 
See "/components/scrollbar#horizontal" demo for represent
If in some cases some peoples affects they from outside (sets background to div.content, for example), that may makes troubles for them
