### PR TITLE
fix(docs/checkbox-block): form control name on example 1

### DIFF
--- a/projects/demo/src/modules/components/checkbox-block/examples/1/index.html
+++ b/projects/demo/src/modules/components/checkbox-block/examples/1/index.html
@@ -12,7 +12,7 @@
     <div class="tui-form__row">
         <tui-checkbox-block
             i18n
-            formControlName="testValue1"
+            formControlName="testValue2"
             contentAlign="right"
             size="m"
         >
@@ -23,7 +23,7 @@
         <tui-checkbox-block
             i18n
             contentAlign="right"
-            formControlName="testValue2"
+            formControlName="testValue3"
             size="l"
         >
             Other


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
-   [x] Tests for the changes have been added (for bug fixes / features)
-   [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

-   [ ] Bugfix
-   [ ] Feature
-   [ ] Refactoring (no functional changes, no api changes)
-   [x] Other... Please describe: Fix docs example for checkbox block.

## What is the current behavior?

Example 1 of the checkbox block is referencing the same form control for multiple checkboxes. No functional issue, but inconsistent with the component class having 3 controls listed on the form group.

## What is the new behavior?

Uses `testValue1`, `testValue2` and `testValue3` form controls for the separate checkbox form controls.

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

