### PR TITLE
fix(primitive-textfield/controller): token naming

### DIFF
--- a/projects/core/components/primitive-textfield/primitive-textfield.component.ts
+++ b/projects/core/components/primitive-textfield/primitive-textfield.component.ts
@@ -24,7 +24,7 @@ import {
     TuiHintControllerDirective,
 } from '@taiga-ui/core/directives/hint-controller';
 import {
-    TUI_TEXTIFELD_WATCHED_CONTROLLER,
+    TUI_TEXTFIELD_WATCHED_CONTROLLER,
     TuiTextfieldController,
 } from '@taiga-ui/core/directives/textfield-controller';
 import {TuiAppearance} from '@taiga-ui/core/enums';
@@ -110,7 +110,7 @@ export class TuiPrimitiveTextfieldComponent
     constructor(
         @Inject(TUI_MODE) readonly mode$: Observable<TuiBrightness | null>,
         @Inject(TUI_TEXTFIELD_APPEARANCE) readonly appearance: string,
-        @Inject(TUI_TEXTIFELD_WATCHED_CONTROLLER)
+        @Inject(TUI_TEXTFIELD_WATCHED_CONTROLLER)
         readonly controller: TuiTextfieldController,
         @Inject(TUI_HINT_WATCHED_CONTROLLER)
         readonly hintController: TuiHintControllerDirective,

--- a/projects/core/directives/textfield-controller/textfield-controller.provider.ts
+++ b/projects/core/directives/textfield-controller/textfield-controller.provider.ts
@@ -34,7 +34,7 @@ import {TUI_TEXTFIELD_SIZE, TuiTextfieldSizeDirective} from './textfield-size.di
 import {TUI_TEXTFIELD_TYPE, TuiTextfieldTypeDirective} from './textfield-type.directive';
 import {TuiTextfieldController} from './textfield.controller';
 
-export const TUI_TEXTIFELD_WATCHED_CONTROLLER = new InjectionToken<TuiTextfieldController>(
+export const TUI_TEXTFIELD_WATCHED_CONTROLLER = new InjectionToken<TuiTextfieldController>(
     'watched textfield controller',
 );
 
@@ -67,7 +67,7 @@ export function textfieldWatchedControllerFactory(
 export const TEXTFIELD_CONTROLLER_PROVIDER: Provider = [
     TuiDestroyService,
     {
-        provide: TUI_TEXTIFELD_WATCHED_CONTROLLER,
+        provide: TUI_TEXTFIELD_WATCHED_CONTROLLER,
         deps: [
             ChangeDetectorRef,
             TuiDestroyService,

--- a/projects/kit/components/input-tag/input-tag.component.ts
+++ b/projects/kit/components/input-tag/input-tag.component.ts
@@ -42,7 +42,7 @@ import {
     TUI_DATA_LIST_HOST,
     TUI_HINT_WATCHED_CONTROLLER,
     TUI_TEXTFIELD_APPEARANCE,
-    TUI_TEXTIFELD_WATCHED_CONTROLLER,
+    TUI_TEXTFIELD_WATCHED_CONTROLLER,
     TuiDataListDirective,
     TuiDataListHost,
     TuiHintControllerDirective,
@@ -184,7 +184,7 @@ export class TuiInputTagComponent
         @Inject(TUI_TAG_STATUS) private readonly tagStatus: TuiStatus,
         @Inject(TUI_HINT_WATCHED_CONTROLLER)
         readonly hintController: TuiHintControllerDirective,
-        @Inject(TUI_TEXTIFELD_WATCHED_CONTROLLER)
+        @Inject(TUI_TEXTFIELD_WATCHED_CONTROLLER)
         readonly controller: TuiTextfieldController,
     ) {
         super(control, changeDetectorRef);

--- a/projects/kit/components/text-area/text-area.component.ts
+++ b/projects/kit/components/text-area/text-area.component.ts
@@ -26,7 +26,7 @@ import {
     TEXTFIELD_CONTROLLER_PROVIDER,
     TUI_HINT_WATCHED_CONTROLLER,
     TUI_TEXTFIELD_APPEARANCE,
-    TUI_TEXTIFELD_WATCHED_CONTROLLER,
+    TUI_TEXTFIELD_WATCHED_CONTROLLER,
     TuiBrightness,
     TuiHintControllerDirective,
     TuiModeDirective,
@@ -82,7 +82,7 @@ export class TuiTextAreaComponent
         @Optional()
         @Inject(TuiModeDirective)
         private readonly modeDirective: TuiModeDirective | null,
-        @Inject(TUI_TEXTIFELD_WATCHED_CONTROLLER)
+        @Inject(TUI_TEXTFIELD_WATCHED_CONTROLLER)
         readonly controller: TuiTextfieldController,
         @Inject(TUI_HINT_WATCHED_CONTROLLER)
         readonly hintController: TuiHintControllerDirective,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
-   [x] Tests for the changes have been added (for bug fixes / features)
-   [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

-   [ ] Bugfix
-   [ ] Feature
-   [x] Refactoring (no functional changes, no api changes)
-   [x] Other... Please describe: Technically renames an existing injection token, so will cause issues for anywhere people are providing to this token in their own implementations.

## What is the current behavior?

The injection token for the text field watched controller is misspelled. 

## What is the new behavior?

`TUI_TEXTIFELD_WATCHED_CONTROLLER` has been renamed to `TUI_TEXTFIELD_WATCHED_CONTROLLER`.

## Does this PR introduce a breaking change?

-   [x] Yes
-   [ ] No

## Other information

If you're open to tools to help alleviate these issues, I strongly recommend the "Code Spell Checker" extension for VSCode. It allows to you have whitelisted phrases/words that are local to the repository, but also will blue underline potentially misspelled variables, comments, etc. We use it on my team and it's been great 👍 