### PR TITLE
feat(core): base skeleton vibe animation on opacity instead of backgroundColor

### DIFF
--- a/projects/core/styles/basic/keyframes.less
+++ b/projects/core/styles/basic/keyframes.less
@@ -18,22 +18,12 @@
     }
 }
 
-@keyframes tuiSkeletonBackgroundVibe {
+@keyframes tuiSkeletonVibe {
     from {
-        background-color: fade(#000, 8%);
+        opacity: 1;
     }
 
     to {
-        background-color: fade(#000, 16%);
-    }
-}
-
-@keyframes tuiSkeletonLightBackgroundVibe {
-    from {
-        background-color: fade(#fff, 16%);
-    }
-
-    to {
-        background-color: fade(#fff, 24%);
+        opacity: 0.5;
     }
 }

--- a/projects/core/styles/markup/tui-skeleton.less
+++ b/projects/core/styles/markup/tui-skeleton.less
@@ -8,13 +8,12 @@
     &:after {
         .fullsize();
         content: '';
-        background-color: fade(#000, 8%);
-        animation: tuiSkeletonBackgroundVibe ease-in-out 1s infinite alternate;
+        background-color: fade(#000, 16%);
+        animation: tuiSkeletonVibe ease-in-out 1s infinite alternate;
     }
 
     &_light:after {
-        background-color: fade(#000, 16%);
-        animation-name: tuiSkeletonLightBackgroundVibe;
+        background-color: fade(#fff, 24%);
     }
 
     &_rounded:after {

--- a/projects/kit/directives/lazy-loading/lazy-loading.directive.ts
+++ b/projects/kit/directives/lazy-loading/lazy-loading.directive.ts
@@ -44,16 +44,12 @@ export class TuiLazyLoadingDirective {
     ) {
         fromEvent(this.elementRef.nativeElement, 'load')
             .pipe(takeUntil(destroy$), watch(changeDetectorRef))
-            .subscribe(() => this.cancelSkeletonAnimation());
+            .subscribe(() => (this.animation = ''));
 
         if (!this.supported) {
             this.src$.subscribe(src => {
                 this.src = src;
             });
         }
-    }
-
-    private cancelSkeletonAnimation() {
-        this.animation = '';
     }
 }

--- a/projects/kit/directives/lazy-loading/lazy-loading.directive.ts
+++ b/projects/kit/directives/lazy-loading/lazy-loading.directive.ts
@@ -7,7 +7,7 @@ import {
     Input,
 } from '@angular/core';
 import {IntersectionObserverService} from '@ng-web-apis/intersection-observer';
-import {TuiDestroyService} from '@taiga-ui/cdk';
+import {TuiDestroyService, watch} from '@taiga-ui/cdk';
 import {fromEvent} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
 import {TuiLazyLoadingService} from './lazy-loading.service';
@@ -37,14 +37,14 @@ export class TuiLazyLoadingDirective {
     constructor(
         @Inject(TuiDestroyService)
         private readonly destroy$: TuiDestroyService,
-        @Inject(ChangeDetectorRef) private readonly changeDetectorRef: ChangeDetectorRef,
         @Inject(TuiLazyLoadingService)
         private readonly src$: TuiLazyLoadingService,
         @Inject(ElementRef)
         private readonly elementRef: ElementRef<HTMLImageElement>,
+        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
     ) {
         fromEvent(this.elementRef.nativeElement, 'load')
-            .pipe(takeUntil(this.destroy$))
+            .pipe(takeUntil(this.destroy$), watch(changeDetectorRef))
             .subscribe(() => this.cancelSkeletonAnimation());
 
         if (!this.supported) {
@@ -56,6 +56,5 @@ export class TuiLazyLoadingDirective {
 
     private cancelSkeletonAnimation() {
         this.animation = '';
-        this.changeDetectorRef.markForCheck();
     }
 }

--- a/projects/kit/directives/lazy-loading/lazy-loading.directive.ts
+++ b/projects/kit/directives/lazy-loading/lazy-loading.directive.ts
@@ -16,7 +16,6 @@ import {TuiLazyLoadingService} from './lazy-loading.service';
     selector: 'img[loading="lazy"]',
     providers: [TuiLazyLoadingService, IntersectionObserverService, TuiDestroyService],
     host: {
-        '[style.animation]': 'animation',
         '[style.background-color]': '"rgba(0, 0, 0, .16)"',
     },
 })
@@ -27,6 +26,7 @@ export class TuiLazyLoadingDirective {
         this.src$.next(src);
     }
 
+    @HostBinding('style.animation')
     animation = 'tuiSkeletonVibe ease-in-out 1s infinite alternate';
 
     @HostBinding('attr.src')

--- a/projects/kit/directives/lazy-loading/lazy-loading.directive.ts
+++ b/projects/kit/directives/lazy-loading/lazy-loading.directive.ts
@@ -7,8 +7,7 @@ import {TuiLazyLoadingService} from './lazy-loading.service';
     selector: 'img[loading="lazy"]',
     providers: [TuiLazyLoadingService, IntersectionObserverService, TuiDestroyService],
     host: {
-        '[style.animation]':
-            '"tuiSkeletonBackgroundVibe ease-in-out 1s infinite alternate"',
+        '[style.animation]': '"tuiSkeletonVibe ease-in-out 1s infinite alternate"',
     },
 })
 export class TuiLazyLoadingDirective {

--- a/projects/kit/directives/lazy-loading/lazy-loading.directive.ts
+++ b/projects/kit/directives/lazy-loading/lazy-loading.directive.ts
@@ -8,10 +8,9 @@ import {
 } from '@angular/core';
 import {IntersectionObserverService} from '@ng-web-apis/intersection-observer';
 import {TuiDestroyService} from '@taiga-ui/cdk';
-import {TuiLazyLoadingService} from './lazy-loading.service';
-
 import {fromEvent} from 'rxjs';
 import {takeUntil} from 'rxjs/operators';
+import {TuiLazyLoadingService} from './lazy-loading.service';
 
 @Directive({
     selector: 'img[loading="lazy"]',

--- a/projects/kit/directives/lazy-loading/lazy-loading.directive.ts
+++ b/projects/kit/directives/lazy-loading/lazy-loading.directive.ts
@@ -35,16 +35,15 @@ export class TuiLazyLoadingDirective {
     private readonly supported = 'loading' in this.elementRef.nativeElement;
 
     constructor(
-        @Inject(TuiDestroyService)
-        private readonly destroy$: TuiDestroyService,
         @Inject(TuiLazyLoadingService)
         private readonly src$: TuiLazyLoadingService,
         @Inject(ElementRef)
         private readonly elementRef: ElementRef<HTMLImageElement>,
+        @Inject(TuiDestroyService) destroy$: TuiDestroyService,
         @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
     ) {
         fromEvent(this.elementRef.nativeElement, 'load')
-            .pipe(takeUntil(this.destroy$), watch(changeDetectorRef))
+            .pipe(takeUntil(destroy$), watch(changeDetectorRef))
             .subscribe(() => this.cancelSkeletonAnimation());
 
         if (!this.supported) {

--- a/projects/kit/directives/lazy-loading/lazy-loading.directive.ts
+++ b/projects/kit/directives/lazy-loading/lazy-loading.directive.ts
@@ -15,12 +15,7 @@ import {takeUntil} from 'rxjs/operators';
 
 @Directive({
     selector: 'img[loading="lazy"]',
-    providers: [
-        TuiDestroyService,
-        TuiLazyLoadingService,
-        IntersectionObserverService,
-        TuiDestroyService,
-    ],
+    providers: [TuiLazyLoadingService, IntersectionObserverService, TuiDestroyService],
     host: {
         '[style.animation]': 'animation',
         '[style.background-color]': '"rgba(0, 0, 0, .16)"',

--- a/projects/kit/directives/lazy-loading/test/lazy-loading.directive.spec.ts
+++ b/projects/kit/directives/lazy-loading/test/lazy-loading.directive.spec.ts
@@ -1,13 +1,12 @@
 import {Component} from '@angular/core';
 import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {TuiLazyLoadingModule} from '@taiga-ui/kit/directives';
 import {configureTestSuite} from 'ng-bullet';
 import {fromEvent} from 'rxjs';
 
-import {TuiLazyLoadingModule} from '@taiga-ui/kit/directives';
-
 describe('TuiLazyLoading directive', () => {
     @Component({
-        template: ` <img id="image" loading="lazy" src="https://picsum.photos/1/1" /> `,
+        template: `<img id="image" loading="lazy" src="https://picsum.photos/1/1" />`,
     })
     class TestComponent {}
 

--- a/projects/kit/directives/lazy-loading/test/lazy-loading.directive.spec.ts
+++ b/projects/kit/directives/lazy-loading/test/lazy-loading.directive.spec.ts
@@ -1,0 +1,54 @@
+import {Component} from '@angular/core';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
+import {configureTestSuite} from 'ng-bullet';
+import {fromEvent} from 'rxjs';
+
+import {TuiLazyLoadingModule} from '@taiga-ui/kit/directives';
+
+describe('TuiLazyLoading directive', () => {
+    @Component({
+        template: ` <img id="image" loading="lazy" src="https://picsum.photos/1/1" /> `,
+    })
+    class TestComponent {}
+
+    configureTestSuite(() => {
+        TestBed.configureTestingModule({
+            imports: [TuiLazyLoadingModule],
+            declarations: [TestComponent],
+        });
+    });
+
+    let fixture: ComponentFixture<TestComponent>;
+
+    beforeEach(() => {
+        fixture = TestBed.createComponent(TestComponent);
+
+        fixture.detectChanges();
+    });
+
+    it('Image has background color', () => {
+        expect(
+            (document.querySelector('#image')! as HTMLImageElement).style.backgroundColor,
+        ).toBe('rgba(0, 0, 0, 0.16)');
+    });
+
+    it('Loading animation is shown', () => {
+        expect(
+            (document.querySelector('#image')! as HTMLImageElement).style.animationName,
+        ).toContain('tuiSkeletonVibe');
+    });
+
+    it('Loading animation is cancelled after image load', done => {
+        fromEvent(
+            document.querySelector('#image')! as HTMLImageElement,
+            'load',
+        ).subscribe(() => {
+            fixture.detectChanges();
+            expect(
+                (document.querySelector('#image')! as HTMLImageElement).style
+                    .animationName,
+            ).toBe('');
+            done();
+        });
+    });
+});


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
-   [x] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [x] Feature
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Other... Please describe:

## What is the current behavior?

Skeleton animation uses backgroundColor property which causes page repaint each frame. With lots of content on a page, many lazy loaded images, or heavy tasks in the background, this can cause noticeable performance issue.

[https://developers.google.com/web/fundamentals/performance/rendering/stick-to-compositor-only-properties-and-manage-layer-count](https://developers.google.com/web/fundamentals/performance/rendering/stick-to-compositor-only-properties-and-manage-layer-count)

Closes #

## What is the new behavior?

tuiSkeletonBackgroundVibe has been replaced with tuiSkeletonVibe animation which only uses opacity property instead. Skeleton elements now have base background color, and the "vibe" effect is achieved by manipulating opacity.

To make it work for TuiLazyLoadingDirective, new host binding for background color had to be made, making the opacity animation visible. Since opacity animation would still be visible after image load, there had to be a _load_ event detection followed by an animation cancel. 

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
