### PR TITLE
feat(core): keep notifications open if hovered

### DIFF
--- a/projects/core/modules/notifications/notification-alert/notification-alert.component.ts
+++ b/projects/core/modules/notifications/notification-alert/notification-alert.component.ts
@@ -31,11 +31,11 @@ export class TuiNotificationAlertComponent<O, I> {
     ) {
         timer(ALERT_AUTOCLOSE_TIMEOUT)
             .pipe(
-                takeUntil(race(destroy$, fromEvent(nativeElement, 'mouseover'))),
+                takeUntil(race(destroy$, fromEvent(nativeElement, 'mouseenter'))),
                 repeatWhen(() => fromEvent(nativeElement, 'mouseleave')),
                 filter(() => this.safeItem.autoClose),
             )
-            .subscribe(() => this.closeDialog());
+            .subscribe(() => this.closeNotification());
     }
 
     get safeItem(): NotificationAlert<O, I> {
@@ -50,7 +50,7 @@ export class TuiNotificationAlertComponent<O, I> {
         return this.calculateContext(this.safeItem);
     }
 
-    closeDialog() {
+    closeNotification() {
         this.safeItem.observer.complete();
     }
 

--- a/projects/core/modules/notifications/notification-alert/notification-alert.component.ts
+++ b/projects/core/modules/notifications/notification-alert/notification-alert.component.ts
@@ -6,7 +6,7 @@ import {
     Input,
 } from '@angular/core';
 import {TuiDestroyService, tuiPure} from '@taiga-ui/cdk';
-import {fromEvent, race, timer} from 'rxjs';
+import {fromEvent, timer} from 'rxjs';
 import {filter, repeatWhen, takeUntil} from 'rxjs/operators';
 
 import {TuiNotificationContentContext} from '../notification-content-context';
@@ -31,8 +31,9 @@ export class TuiNotificationAlertComponent<O, I> {
     ) {
         timer(ALERT_AUTOCLOSE_TIMEOUT)
             .pipe(
-                takeUntil(race(destroy$, fromEvent(nativeElement, 'mouseenter'))),
+                takeUntil(fromEvent(nativeElement, 'mouseenter')),
                 repeatWhen(() => fromEvent(nativeElement, 'mouseleave')),
+                takeUntil(destroy$),
                 filter(() => this.safeItem.autoClose),
             )
             .subscribe(() => this.closeNotification());

--- a/projects/core/modules/notifications/notification-alert/notification-alert.template.html
+++ b/projects/core/modules/notifications/notification-alert/notification-alert.template.html
@@ -2,7 +2,7 @@
     *ngIf="safeItem.hasCloseButton else noClose"
     [status]="safeItem.status"
     [hasIcon]="safeItem.hasIcon"
-    (close)="closeDialog()"
+    (close)="closeNotification()"
 >
     <label
         *ngIf="safeItem.label"

--- a/projects/core/modules/notifications/notification-alert/test/notification-alert.component.spec.ts
+++ b/projects/core/modules/notifications/notification-alert/test/notification-alert.component.spec.ts
@@ -132,7 +132,7 @@ describe('NotificationAlertComponent', () => {
 
     it('close | Close the Alert and notify the observer', () => {
         fixture.detectChanges();
-        component.closeDialog();
+        component.closeNotification();
 
         expect(nextSpy).not.toHaveBeenCalled();
         expect(completeSpy).toHaveBeenCalled();


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [x] Feature
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Other... Please describe:

## What is the current behavior?

Currently notification with auto close feature closes automatically after 3000ms no matter what. This does not allow users to hold the notification and read its content.

Closes https://github.com/TinkoffCreditSystems/taiga-ui/issues/417

## What is the new behavior?

Whenever user _mouseover_ over notification, the auto close timer will be cancelled. Notification will automatically start closing again after user's _mouseleave_ action.

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This has been implemented in basically the same way as taking a screenshot on MacOS and hovering over the thumbnail.
