### PR TITLE
fix(core): remove calendar jumps

### DIFF
--- a/projects/core/components/calendar/calendar.component.ts
+++ b/projects/core/components/calendar/calendar.component.ts
@@ -3,6 +3,7 @@ import {
     Component,
     EventEmitter,
     Input,
+    OnInit,
     Output,
 } from '@angular/core';
 import {
@@ -29,7 +30,7 @@ import {TuiMarkerHandler} from '@taiga-ui/core/types';
     styleUrls: ['./calendar.style.less'],
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class TuiCalendarComponent implements TuiWithOptionalMinMax<TuiDay> {
+export class TuiCalendarComponent implements TuiWithOptionalMinMax<TuiDay>, OnInit {
     @Input()
     @tuiDefaultProp()
     month = TuiMonth.currentLocal();
@@ -81,25 +82,21 @@ export class TuiCalendarComponent implements TuiWithOptionalMinMax<TuiDay> {
 
     year: TuiYear | null = null;
 
+    ngOnInit(): void {
+        const {month, computedMinViewedMonth, computedMaxViewedMonth} = this;
+
+        if (month.monthBefore(computedMinViewedMonth)) {
+            this.month = computedMinViewedMonth;
+        } else if (month.monthAfter(computedMaxViewedMonth)) {
+            this.month = computedMaxViewedMonth;
+        }
+    }
+
     readonly disabledItemHandlerMapper: TuiMapper<
         TuiBooleanHandler<TuiDay>,
         TuiBooleanHandler<TuiDay>
     > = (disabledItemHandler, min: TuiDay, max: TuiDay) => item =>
         item.dayBefore(min) || item.dayAfter(max) || disabledItemHandler(item);
-
-    get computedMonth(): TuiMonth {
-        const {month, computedMinViewedMonth, computedMaxViewedMonth} = this;
-
-        if (month.monthBefore(computedMinViewedMonth)) {
-            return computedMinViewedMonth;
-        }
-
-        if (month.monthAfter(computedMaxViewedMonth)) {
-            return computedMaxViewedMonth;
-        }
-
-        return month;
-    }
 
     get computedMinViewedMonth(): TuiMonth {
         return this.minViewedMonth.monthSameOrAfter(this.min)
@@ -119,7 +116,7 @@ export class TuiCalendarComponent implements TuiWithOptionalMinMax<TuiDay> {
 
     onPickerYearClick({year}: TuiYear) {
         this.year = null;
-        this.updateViewedMonth(new TuiMonth(year, this.computedMonth.month));
+        this.updateViewedMonth(new TuiMonth(year, this.month.month));
     }
 
     onPaginationValueChange(month: TuiMonth) {

--- a/projects/core/components/calendar/calendar.component.ts
+++ b/projects/core/components/calendar/calendar.component.ts
@@ -30,19 +30,9 @@ import {TuiMarkerHandler} from '@taiga-ui/core/types';
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TuiCalendarComponent implements TuiWithOptionalMinMax<TuiDay> {
-    @Input('month')
-    set monthSetter(month: TuiMonth) {
-        const {computedMinViewedMonth, computedMaxViewedMonth} = this;
-
-        if (month.monthBefore(computedMinViewedMonth)) {
-            this.month = computedMinViewedMonth;
-        } else if (month.monthAfter(computedMaxViewedMonth)) {
-            this.month = computedMaxViewedMonth;
-        } else {
-            this.month = month;
-        }
-    }
-    month = TuiMonth.currentLocal();
+    @Input()
+    @tuiDefaultProp()
+    month: TuiMonth = TuiMonth.currentLocal();
 
     @Input()
     @tuiDefaultProp()

--- a/projects/core/components/calendar/calendar.component.ts
+++ b/projects/core/components/calendar/calendar.component.ts
@@ -3,7 +3,6 @@ import {
     Component,
     EventEmitter,
     Input,
-    OnInit,
     Output,
 } from '@angular/core';
 import {
@@ -30,9 +29,19 @@ import {TuiMarkerHandler} from '@taiga-ui/core/types';
     styleUrls: ['./calendar.style.less'],
     changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class TuiCalendarComponent implements TuiWithOptionalMinMax<TuiDay>, OnInit {
-    @Input()
-    @tuiDefaultProp()
+export class TuiCalendarComponent implements TuiWithOptionalMinMax<TuiDay> {
+    @Input('month')
+    set monthSetter(month: TuiMonth) {
+        const {computedMinViewedMonth, computedMaxViewedMonth} = this;
+
+        if (month.monthBefore(computedMinViewedMonth)) {
+            this.month = computedMinViewedMonth;
+        } else if (month.monthAfter(computedMaxViewedMonth)) {
+            this.month = computedMaxViewedMonth;
+        } else {
+            this.month = month;
+        }
+    }
     month = TuiMonth.currentLocal();
 
     @Input()
@@ -81,16 +90,6 @@ export class TuiCalendarComponent implements TuiWithOptionalMinMax<TuiDay>, OnIn
     readonly hoveredItemChange = new EventEmitter<TuiDay | null>();
 
     year: TuiYear | null = null;
-
-    ngOnInit(): void {
-        const {month, computedMinViewedMonth, computedMaxViewedMonth} = this;
-
-        if (month.monthBefore(computedMinViewedMonth)) {
-            this.month = computedMinViewedMonth;
-        } else if (month.monthAfter(computedMaxViewedMonth)) {
-            this.month = computedMaxViewedMonth;
-        }
-    }
 
     readonly disabledItemHandlerMapper: TuiMapper<
         TuiBooleanHandler<TuiDay>,

--- a/projects/core/components/calendar/calendar.template.html
+++ b/projects/core/components/calendar/calendar.template.html
@@ -18,7 +18,7 @@
         automation-id="tui-calendar__pagination"
         [min]="computedMinViewedMonth"
         [max]="computedMaxViewedMonth"
-        [value]="computedMonth"
+        [value]="month"
         (valueChange)="onPaginationValueChange($event)"
         (yearClick)="onPaginationYearClick($event)"
     ></tui-primitive-year-month-pagination>
@@ -26,7 +26,7 @@
         automation-id="tui-calendar__calendar"
         [showAdjacent]="showAdjacent"
         [value]="value"
-        [month]="computedMonth"
+        [month]="month"
         [disabledItemHandler]="disabledItemHandler | tuiMapper : disabledItemHandlerMapper : min : max"
         [markerHandler]="markerHandler"
         [hoveredItem]="hoveredItem"

--- a/projects/core/components/calendar/test/calendar.component.spec.ts
+++ b/projects/core/components/calendar/test/calendar.component.spec.ts
@@ -89,8 +89,9 @@ describe('Calendar', () => {
     });
 
     it('onPaginationValueChange does not update month if it is the same with current', () => {
-        const savedMonth = new TuiMonth(2002, 2);
-        const sameMonth = new TuiMonth(2002, 2);
+        const date = new Date();
+        const savedMonth = new TuiMonth(date.getFullYear(), date.getMonth());
+        const sameMonth = new TuiMonth(date.getFullYear(), date.getMonth());
 
         component.month = savedMonth;
 
@@ -145,21 +146,5 @@ describe('Calendar', () => {
         component.maxViewedMonth = afterMaxDay;
 
         expect(component.computedMaxViewedMonth).toBe(maxDay);
-    });
-
-    it('if set month is less than viewed, it takes computed min viewed', () => {
-        const month = TuiMonth.currentLocal();
-        const monthAfter = month.append({month: 1});
-
-        component.minViewedMonth = monthAfter;
-        component.month = month;
-
-        expect(component.month).toBe(monthAfter);
-    });
-
-    it('if set month is more than max, it takes max viewed', () => {
-        component.max = TuiDay.currentLocal().append({month: -1});
-        component.month = TuiDay.currentLocal();
-        expect(component.month).toBe(component.max);
     });
 });

--- a/projects/core/components/calendar/test/calendar.component.spec.ts
+++ b/projects/core/components/calendar/test/calendar.component.spec.ts
@@ -146,4 +146,20 @@ describe('Calendar', () => {
 
         expect(component.computedMaxViewedMonth).toBe(maxDay);
     });
+
+    it('if set month is less than viewed, it takes computed min viewed', () => {
+        const month = TuiMonth.currentLocal();
+        const monthAfter = month.append({month: 1});
+
+        component.minViewedMonth = monthAfter;
+        component.month = month;
+
+        expect(component.month).toBe(monthAfter);
+    });
+
+    it('if set month is more than max, it takes max viewed', () => {
+        component.max = TuiDay.currentLocal().append({month: -1});
+        component.month = TuiDay.currentLocal();
+        expect(component.month).toBe(component.max);
+    });
 });

--- a/projects/core/components/calendar/test/calendar.component.spec.ts
+++ b/projects/core/components/calendar/test/calendar.component.spec.ts
@@ -146,20 +146,4 @@ describe('Calendar', () => {
 
         expect(component.computedMaxViewedMonth).toBe(maxDay);
     });
-
-    it('if set month is less than viewed, it takes computed min viewed', () => {
-        const month = TuiMonth.currentLocal();
-        const monthAfter = month.append({month: 1});
-
-        component.month = month;
-        component.minViewedMonth = monthAfter;
-
-        expect(component.computedMonth).toBe(monthAfter);
-    });
-
-    it('if set month is more than max, it takes max viewed', () => {
-        component.max = TuiDay.currentLocal().append({month: -1});
-
-        expect(component.computedMonth).toBe(component.max);
-    });
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [ ] Feature
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Other... Please describe:

## What is the current behavior?

When user selects a date in calendarRange and current range limit exceeds number of days in either left / right side calendars, we do jump on another month.

Closes https://github.com/TinkoffCreditSystems/taiga-ui/issues/418

## What is the new behavior?

When user selects a date in calendarRange and current range limit exceeds number of days in either left / right side calendars, we do not jump on another month.

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Not sure if we need the foolproof in ngOnInit, lmk if i need to remove that.