### PR TITLE
chore(demo): fix typos at InputNumber component docs

### DIFF
--- a/projects/demo/src/locale/messages.xlf
+++ b/projects/demo/src/locale/messages.xlf
@@ -4835,7 +4835,7 @@
       </trans-unit>
       <trans-unit id="134e4e36c9b1796301b1b7d1d6f8cd006f4ed044" datatype="html">
         <source>
-            InputNumber — is a component to inout numbers. Inputed
+            InputNumber — is a component to input numbers. Inputed
             value is formatted: thousands are separated with space. A control
             value of the component is a number.
         </source>
@@ -4863,7 +4863,7 @@
             <x id="START_LINK_1" ctype="x-a" equiv-text="&lt;a&gt;"/><x id="START_TAG_CODE" ctype="x-code" equiv-text="&lt;code&gt;"/>Slider<x id="CLOSE_TAG_CODE" ctype="x-code" equiv-text="&lt;/code&gt;"/><x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>
             and
             <x id="START_LINK_2" ctype="x-a" equiv-text="&lt;a&gt;"/><x id="START_TAG_CODE" ctype="x-code" equiv-text="&lt;code&gt;"/>InputSlider<x id="CLOSE_TAG_CODE" ctype="x-code" equiv-text="&lt;/code&gt;"/><x id="CLOSE_LINK" ctype="x-a" equiv-text="&lt;/a&gt;"/>
-            for inputing with a slider
+            for inputting with a slider
         </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/modules/components/input-number/input-number.template.html</context>

--- a/projects/demo/src/modules/components/input-number/input-number.template.html
+++ b/projects/demo/src/modules/components/input-number/input-number.template.html
@@ -1,7 +1,7 @@
 <tui-doc-page header="InputNumber" package="KIT" type="components">
     <ng-template pageTab>
         <div i18n class="tui-space_bottom-3">
-            InputNumber&nbsp;&mdash; is a component to inout numbers. Inputed
+            InputNumber&nbsp;&mdash; is a component to input numbers. Inputed
             value is formatted: thousands are separated with space. A control
             value of the component is a number.
         </div>
@@ -23,7 +23,7 @@
             <a tuiLink routerLink="/components/input-slider"
                 ><code>InputSlider</code></a
             >
-            for inputing with a slider
+            for inputting with a slider
         </p>
 
         <tui-doc-example


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [ ] Feature
-   [x] Refactoring (no functional changes, no api changes)
-   [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

Right now docs have typos at `InputNumber — is a component to inout numbers` and `InputSlider for inputing with a slider`.

Closes #

## What is the new behavior?
These typos were fixed.

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Before:

![image](https://user-images.githubusercontent.com/11725955/124680926-b6b36380-dec7-11eb-88a9-15b85ed650a6.png)

After:

![image](https://user-images.githubusercontent.com/11725955/124680891-a26f6680-dec7-11eb-9985-78a1be4f7994.png)

