### PR TITLE
fix(kit): `getClipboardDataText` return text/plain format as fallback

### DIFF
--- a/projects/cdk/utils/dom/get-clipboard-data-text.ts
+++ b/projects/cdk/utils/dom/get-clipboard-data-text.ts
@@ -1,11 +1,14 @@
+const DEFAULT_FORMAT = 'text/plain';
+
 /**
  * Gets text from data of clipboardEvent, it also works in IE and Edge browsers
  */
 export function getClipboardDataText(
     event: ClipboardEvent,
-    format: string = 'text/plain',
+    format: string = DEFAULT_FORMAT,
 ): string {
     return 'clipboardData' in event && event.clipboardData !== null
-        ? event.clipboardData.getData(format)
+        ? event.clipboardData.getData(format) ||
+              event.clipboardData.getData(DEFAULT_FORMAT)
         : (event as any).target.ownerDocument.defaultView.clipboardData.getData('text');
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [ ] Feature
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Other... Please describe:

## What is the current behavior?

https://github.com/TinkoffCreditSystems/taiga-ui/issues/567

Closes #567 

## What is the new behavior?

If empty string received for text/html format, `getClipboardDataText` fallbacks to text/plain format

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

## Other information
