### PR TITLE
fix(cdk): make `markControlAsTouchedAndValidate` work with empty FormArray and FormGroup

### DIFF
--- a/projects/cdk/utils/miscellaneous/mark-control-as-touched-and-validate.ts
+++ b/projects/cdk/utils/miscellaneous/mark-control-as-touched-and-validate.ts
@@ -1,6 +1,9 @@
 import {AbstractControl, FormArray, FormGroup} from '@angular/forms';
 
 export function markControlAsTouchedAndValidate(control: AbstractControl) {
+    control.markAsTouched();
+    control.updateValueAndValidity();
+
     if (control instanceof FormArray) {
         control.controls.forEach(nestedControl => {
             markControlAsTouchedAndValidate(nestedControl);
@@ -16,7 +19,4 @@ export function markControlAsTouchedAndValidate(control: AbstractControl) {
 
         return;
     }
-
-    control.markAsTouched();
-    control.updateValueAndValidity();
 }

--- a/projects/cdk/utils/miscellaneous/mark-control-as-touched-and-validate.ts
+++ b/projects/cdk/utils/miscellaneous/mark-control-as-touched-and-validate.ts
@@ -1,22 +1,18 @@
 import {AbstractControl, FormArray, FormGroup} from '@angular/forms';
 
 export function markControlAsTouchedAndValidate(control: AbstractControl) {
-    control.markAsTouched();
-    control.updateValueAndValidity();
-
     if (control instanceof FormArray) {
         control.controls.forEach(nestedControl => {
             markControlAsTouchedAndValidate(nestedControl);
         });
-
-        return;
     }
 
     if (control instanceof FormGroup) {
         Object.values(control.controls).forEach(nestedControl => {
             markControlAsTouchedAndValidate(nestedControl);
         });
-
-        return;
     }
+
+    control.markAsTouched();
+    control.updateValueAndValidity();
 }

--- a/projects/cdk/utils/miscellaneous/test/mark-control-as-touched-and-validate.spec.ts
+++ b/projects/cdk/utils/miscellaneous/test/mark-control-as-touched-and-validate.spec.ts
@@ -22,6 +22,14 @@ describe('markControlAsTouchedAndValidate', () => {
         expect(group.get('control2')!.touched).toBe(true);
     });
 
+    it('With empty form group', () => {
+        const group = new FormGroup({});
+
+        markControlAsTouchedAndValidate(group);
+
+        expect(group.touched).toBe(true);
+    });
+
     it('FormArray', () => {
         const array = new FormArray([new FormControl(), new FormControl()]);
 
@@ -29,6 +37,14 @@ describe('markControlAsTouchedAndValidate', () => {
 
         expect(array.at(0).touched).toBe(true);
         expect(array.at(1).touched).toBe(true);
+    });
+
+    it('With empty form array', () => {
+        const array = new FormArray([]);
+
+        markControlAsTouchedAndValidate(array);
+
+        expect(array.touched).toBe(true);
     });
 
     it('With nested form arrays', () => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
-   [x] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [x] Bugfix
-   [ ] Feature
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Other... Please describe:

## What is the current behavior?

Currently `markControlAsTouchedAndValidate` is not setting `touched: true` on FormArray or FormGroup with empty controls
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?

Set `touched: true` on empty FormArray or FormGroup

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

