### PR TITLE
feat(i18n): Correct abbreviation for Monday in German

### DIFF
--- a/projects/i18n/languages/german/core.ts
+++ b/projects/i18n/languages/german/core.ts
@@ -20,7 +20,7 @@ export const TUI_GERMAN_LANGUAGE_CORE: LanguageCore = {
     nothingFoundMessage: 'Keine Ergebnisse',
     defaultErrorMessage: 'Wert ist ungültig',
     spinTexts: ['Zurück', 'Weiter'],
-    shortWeekDays: ['Mon', 'Di', 'Mi', 'Do', 'Fr', 'Sa', 'So'],
+    shortWeekDays: ['Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa', 'So'],
     // TODO: i18n replace with current language countries list
     countries: TUI_ENGLISH_LANGUAGE_COUNTRIES,
 };


### PR DESCRIPTION
Mon. is wrong. It is Mo.
See: [Duden](https://www.duden.de/rechtschreibung/Mo_)

And normally you put a point behind. But not sure if this is necessary here...