### PR TITLE
fix(addon-doc): fix overlapping by sticky header while using anchor links

### DIFF
--- a/projects/addon-doc/src/components/main/main.style.less
+++ b/projects/addon-doc/src/components/main/main.style.less
@@ -1,5 +1,11 @@
 @import 'taiga-ui-local';
 
+@sticky-header-height: 4rem;
+
+html {
+    scroll-padding-top: @sticky-header-height;
+}
+
 @keyframes tuiShaking {
     from,
     to {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [X] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [ ] Feature
-   [ ] Refactoring (no functional changes, no api changes)
-   [X] Other... Please describe:

## What is the current behavior?
1. use any anchor link (for example, https://taiga-ui.dev/getting-started#options)
2. beginning of content overlapped by header

Closes #

## What is the new behavior?
No overlapping

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
