### PR TITLE
feat: `TUI_NUMBER_FORMAT` injection token to configure decimals and thousand symbols in number formatting

### DIFF
--- a/projects/addon-commerce/components/money/money.component.ts
+++ b/projects/addon-commerce/components/money/money.component.ts
@@ -8,9 +8,12 @@ import {
 import {TuiCurrency} from '@taiga-ui/addon-commerce/enums';
 import {TuiCurrencyVariants, TuiMoneySignT} from '@taiga-ui/addon-commerce/types';
 import {CHAR_EN_DASH, tuiDefaultProp} from '@taiga-ui/cdk';
-import {formatNumber, TuiDecimalT} from '@taiga-ui/core';
-import {NumberFormatSettings} from '@taiga-ui/core/interfaces/number-format-settings';
-import {TUI_NUMBER_FORMAT} from '@taiga-ui/core/tokens/number-format';
+import {
+    formatNumber,
+    NumberFormatSettings,
+    TUI_NUMBER_FORMAT,
+    TuiDecimalT,
+} from '@taiga-ui/core';
 
 @Component({
     selector: 'tui-money',
@@ -51,8 +54,8 @@ export class TuiMoneyComponent {
         return formatNumber(
             Math.floor(Math.abs(this.value)),
             null,
-            this.numberFormatSettings.decimalSeparator,
-            this.numberFormatSettings.thousandSeparator,
+            this.numberFormat.decimalSeparator,
+            this.numberFormat.thousandSeparator,
         );
     }
 
@@ -63,7 +66,7 @@ export class TuiMoneyComponent {
         return decimal === 'never' ||
             (parseInt(fraction, 10) === 0 && decimal !== 'always')
             ? ''
-            : this.numberFormatSettings.decimalSeparator + fraction;
+            : this.numberFormat.decimalSeparator + fraction;
     }
 
     get signSymbol(): '' | typeof CHAR_EN_DASH | '+' {
@@ -105,6 +108,6 @@ export class TuiMoneyComponent {
 
     constructor(
         @Inject(TUI_NUMBER_FORMAT)
-        private numberFormatSettings: NumberFormatSettings,
+        private readonly numberFormat: NumberFormatSettings,
     ) {}
 }

--- a/projects/addon-commerce/components/money/money.component.ts
+++ b/projects/addon-commerce/components/money/money.component.ts
@@ -1,8 +1,16 @@
-import {ChangeDetectionStrategy, Component, HostBinding, Input} from '@angular/core';
+import {
+    ChangeDetectionStrategy,
+    Component,
+    HostBinding,
+    Inject,
+    Input,
+} from '@angular/core';
 import {TuiCurrency} from '@taiga-ui/addon-commerce/enums';
 import {TuiCurrencyVariants, TuiMoneySignT} from '@taiga-ui/addon-commerce/types';
 import {CHAR_EN_DASH, tuiDefaultProp} from '@taiga-ui/cdk';
 import {formatNumber, TuiDecimalT} from '@taiga-ui/core';
+import {NumberFormatSettings} from '@taiga-ui/core/interfaces/number-format-settings';
+import {TUI_NUMBER_FORMAT} from '@taiga-ui/core/tokens/number-format';
 
 @Component({
     selector: 'tui-money',
@@ -40,7 +48,12 @@ export class TuiMoneyComponent {
     singleColor = false;
 
     get integerPart(): string {
-        return formatNumber(Math.floor(Math.abs(this.value)));
+        return formatNumber(
+            Math.floor(Math.abs(this.value)),
+            null,
+            this.numberFormatSettings.decimalSeparator,
+            this.numberFormatSettings.thousandSeparator,
+        );
     }
 
     get fractionPart(): string {
@@ -50,7 +63,7 @@ export class TuiMoneyComponent {
         return decimal === 'never' ||
             (parseInt(fraction, 10) === 0 && decimal !== 'always')
             ? ''
-            : ',' + fraction;
+            : this.numberFormatSettings.decimalSeparator + fraction;
     }
 
     get signSymbol(): '' | typeof CHAR_EN_DASH | '+' {
@@ -89,4 +102,9 @@ export class TuiMoneyComponent {
     get inheritColor(): boolean {
         return this.singleColor || (this.value === 0 && this.colored);
     }
+
+    constructor(
+        @Inject(TUI_NUMBER_FORMAT)
+        private numberFormatSettings: NumberFormatSettings,
+    ) {}
 }

--- a/projects/core/constants/decimal-symbols.ts
+++ b/projects/core/constants/decimal-symbols.ts
@@ -1,0 +1,1 @@
+export const TUI_DECIMAL_SYMBOLS: ReadonlyArray<string> = [',', '.'];

--- a/projects/core/constants/index.ts
+++ b/projects/core/constants/index.ts
@@ -1,6 +1,7 @@
 export * from './absolute-box-sizes';
 export * from './default-icons-path';
 export * from './default-marker-handler';
+export * from './decimal-symbols';
 export * from './editing-keys';
 export * from './events';
 export * from './mask-caret-trap';

--- a/projects/core/interfaces/index.ts
+++ b/projects/core/interfaces/index.ts
@@ -5,5 +5,6 @@ export * from './dialog-context';
 export * from './dialog-options';
 export * from './dropdown-directive';
 export * from './icon-error';
+export * from './number-format-settings';
 export * from './value-content-context';
 export * from './with-optional-min-max';

--- a/projects/core/interfaces/number-format-settings.ts
+++ b/projects/core/interfaces/number-format-settings.ts
@@ -1,0 +1,11 @@
+import {TuiDecimalSymbol} from '@taiga-ui/core/types';
+
+/**
+ * Formatting configuration for displayed numbers
+ * decimalSeparator - example: 100,45 (',' by default)
+ * thousandSeparator - example: 360 000 (' ' by default)
+ */
+export interface NumberFormatSettings {
+    decimalSeparator: TuiDecimalSymbol;
+    thousandSeparator: string;
+}

--- a/projects/core/interfaces/number-format-settings.ts
+++ b/projects/core/interfaces/number-format-settings.ts
@@ -6,6 +6,6 @@ import {TuiDecimalSymbol} from '@taiga-ui/core/types';
  * thousandSeparator - example: 360 000 (' ' by default)
  */
 export interface NumberFormatSettings {
-    decimalSeparator: TuiDecimalSymbol;
-    thousandSeparator: string;
+    readonly decimalSeparator: TuiDecimalSymbol;
+    readonly thousandSeparator: string;
 }

--- a/projects/core/mask/number-mask-options.ts
+++ b/projects/core/mask/number-mask-options.ts
@@ -3,6 +3,7 @@ import {TuiDecimalSymbol} from '@taiga-ui/core/types';
 export interface TuiNumberMaskOptions {
     readonly allowDecimal?: boolean;
     readonly decimalSymbol?: TuiDecimalSymbol;
+    readonly thousandSymbol?: string;
     readonly autoCorrectDecimalSymbol?: boolean;
     readonly decimalLimit?: number;
     readonly requireDecimal?: boolean;

--- a/projects/core/pipes/format-number/format-number.pipe.ts
+++ b/projects/core/pipes/format-number/format-number.pipe.ts
@@ -1,20 +1,28 @@
-import {Pipe, PipeTransform} from '@angular/core';
+import {Inject, Pipe, PipeTransform} from '@angular/core';
+import {NumberFormatSettings} from '@taiga-ui/core/interfaces/number-format-settings';
+import {TUI_NUMBER_FORMAT} from '@taiga-ui/core/tokens/number-format';
 import {formatNumber} from '@taiga-ui/core/utils/format';
 
 @Pipe({name: 'tuiFormatNumber'})
 export class TuiFormatNumberPipe implements PipeTransform {
+    constructor(
+        @Inject(TUI_NUMBER_FORMAT)
+        protected readonly numberFormatSettings: NumberFormatSettings,
+    ) {}
     /**
      * Formats number adding thousand separators and correct decimal separator
      * padding decimal part with zeroes to given length
      * @param value number
      * @param decimalSeparator
+     * @param thousandSeparator
      * @param decimalLimit number of digits of decimal part, null to keep untouched
      */
     transform(
         value: number,
         decimalLimit: number | null = null,
-        decimalSeparator: string = ',',
+        decimalSeparator: string = this.numberFormatSettings.decimalSeparator,
+        thousandSeparator: string = this.numberFormatSettings.thousandSeparator,
     ): string {
-        return formatNumber(value, decimalLimit, decimalSeparator);
+        return formatNumber(value, decimalLimit, decimalSeparator, thousandSeparator);
     }
 }

--- a/projects/core/pipes/format-number/format-number.pipe.ts
+++ b/projects/core/pipes/format-number/format-number.pipe.ts
@@ -1,13 +1,13 @@
 import {Inject, Pipe, PipeTransform} from '@angular/core';
-import {NumberFormatSettings} from '@taiga-ui/core/interfaces/number-format-settings';
-import {TUI_NUMBER_FORMAT} from '@taiga-ui/core/tokens/number-format';
+import {NumberFormatSettings} from '@taiga-ui/core/interfaces';
+import {TUI_NUMBER_FORMAT} from '@taiga-ui/core/tokens';
 import {formatNumber} from '@taiga-ui/core/utils/format';
 
 @Pipe({name: 'tuiFormatNumber'})
 export class TuiFormatNumberPipe implements PipeTransform {
     constructor(
         @Inject(TUI_NUMBER_FORMAT)
-        protected readonly numberFormatSettings: NumberFormatSettings,
+        private readonly numberFormat: NumberFormatSettings,
     ) {}
     /**
      * Formats number adding thousand separators and correct decimal separator
@@ -20,8 +20,8 @@ export class TuiFormatNumberPipe implements PipeTransform {
     transform(
         value: number,
         decimalLimit: number | null = null,
-        decimalSeparator: string = this.numberFormatSettings.decimalSeparator,
-        thousandSeparator: string = this.numberFormatSettings.thousandSeparator,
+        decimalSeparator: string = this.numberFormat.decimalSeparator,
+        thousandSeparator: string = this.numberFormat.thousandSeparator,
     ): string {
         return formatNumber(value, decimalLimit, decimalSeparator, thousandSeparator);
     }

--- a/projects/core/tokens/index.ts
+++ b/projects/core/tokens/index.ts
@@ -10,6 +10,7 @@ export * from './i18n';
 export * from './icons';
 export * from './icons-path';
 export * from './mode';
+export * from './number-format';
 export * from './option-content';
 export * from './sanitizer';
 export * from './scroll-ref';

--- a/projects/core/tokens/number-format.ts
+++ b/projects/core/tokens/number-format.ts
@@ -1,0 +1,15 @@
+import {InjectionToken} from '@angular/core';
+import { CHAR_NO_BREAK_SPACE } from "@taiga-ui/cdk";
+import {NumberFormatSettings} from '@taiga-ui/core/interfaces/number-format-settings';
+
+export const TUI_NUMBER_FORMAT = new InjectionToken<NumberFormatSettings>(
+    'Formatting configuration for displayed numbers',
+    {
+        factory: () => {
+            return {
+                decimalSeparator: ',',
+                thousandSeparator: CHAR_NO_BREAK_SPACE,
+            };
+        },
+    },
+);

--- a/projects/core/tokens/number-format.ts
+++ b/projects/core/tokens/number-format.ts
@@ -1,15 +1,13 @@
 import {InjectionToken} from '@angular/core';
-import { CHAR_NO_BREAK_SPACE } from "@taiga-ui/cdk";
-import {NumberFormatSettings} from '@taiga-ui/core/interfaces/number-format-settings';
+import {CHAR_NO_BREAK_SPACE} from '@taiga-ui/cdk';
+import {NumberFormatSettings} from '@taiga-ui/core/interfaces';
 
 export const TUI_NUMBER_FORMAT = new InjectionToken<NumberFormatSettings>(
     'Formatting configuration for displayed numbers',
     {
-        factory: () => {
-            return {
-                decimalSeparator: ',',
-                thousandSeparator: CHAR_NO_BREAK_SPACE,
-            };
-        },
+        factory: () => ({
+            decimalSeparator: ',',
+            thousandSeparator: CHAR_NO_BREAK_SPACE,
+        }),
     },
 );

--- a/projects/core/utils/mask/create-auto-corrected-money-pipe.ts
+++ b/projects/core/utils/mask/create-auto-corrected-money-pipe.ts
@@ -14,6 +14,7 @@ import {TuiDecimalSymbol} from '@taiga-ui/core/types';
 export function tuiCreateAutoCorrectedNumberPipe(
     decimalLimit: number = 0,
     decimalSymbol: TuiDecimalSymbol = ',',
+    thousandSymbol: string = CHAR_NO_BREAK_SPACE,
     nativeInput?: HTMLInputElement,
 ): TuiTextMaskPipeHandler {
     tuiAssert.assert(Number.isInteger(decimalLimit));
@@ -52,7 +53,11 @@ export function tuiCreateAutoCorrectedNumberPipe(
         ) {
             const realCaretPosition =
                 config.currentCaretPosition +
-                calculateCaretGap(config.previousConformedValue, conformedValue);
+                calculateCaretGap(
+                    config.previousConformedValue,
+                    conformedValue,
+                    thousandSymbol,
+                );
 
             setTimeout(() => {
                 nativeInput.setSelectionRange(realCaretPosition, realCaretPosition);
@@ -126,15 +131,19 @@ function calculateChangedTailIndex(previous: string, current: string): number {
     return current.length;
 }
 
-function calculateCaretGap(previousValue: string = '', current: string): number {
+function calculateCaretGap(
+    previousValue: string = '',
+    current: string,
+    thousandSymbol: string,
+): number {
     const pasteOrCutOperation = Math.abs(previousValue.length - current.length) > 2;
 
     if (pasteOrCutOperation) {
         return 0;
     }
 
-    const wereSpaces = previousValue.split(CHAR_NO_BREAK_SPACE).length;
-    const nowSpaces = current.split(CHAR_NO_BREAK_SPACE).length;
+    const wereSpaces = previousValue.split(thousandSymbol).length;
+    const nowSpaces = current.split(thousandSymbol).length;
 
     return nowSpaces - wereSpaces;
 }

--- a/projects/core/utils/mask/create-number-mask.ts
+++ b/projects/core/utils/mask/create-number-mask.ts
@@ -16,6 +16,7 @@ const NON_ZERO_DIGIT = /[1-9]/;
 export function tuiCreateNumberMask({
     allowDecimal = false,
     decimalSymbol = ',',
+    thousandSymbol = CHAR_NO_BREAK_SPACE,
     autoCorrectDecimalSymbol = true,
     decimalLimit = 2,
     requireDecimal = false,
@@ -29,13 +30,11 @@ export function tuiCreateNumberMask({
 
     return (rawValue, {previousConformedValue}) => {
         if (previousConformedValue && requireDecimal) {
-            const conformedWithoutSeparator = rawValue
-                .split(CHAR_NO_BREAK_SPACE)
-                .join('');
+            const conformedWithoutSeparator = rawValue.split(thousandSymbol).join('');
             const previousConformedValueWithoutDecimalSymbolAndSeparator = previousConformedValue
-                .split(CHAR_NO_BREAK_SPACE)
+                .split(thousandSymbol)
                 .join('')
-                .split(',')
+                .split(decimalSymbol)
                 .join('');
 
             // Forbid removal of decimal separator if decimal part is required
@@ -68,15 +67,14 @@ export function tuiCreateNumberMask({
         );
         const hasDecimal = decimalIndex !== -1;
         const integer = hasDecimal ? rawValue.slice(0, decimalIndex) : rawValue;
-        const thousandSeparators =
-            integer.match(new RegExp(CHAR_NO_BREAK_SPACE, 'g')) || [];
+        const thousandSeparators = integer.match(new RegExp(thousandSymbol, 'g')) || [];
         const integerCapped = integerLimit
             ? integer.slice(0, integerLimit + thousandSeparators.length)
             : integer;
         const integerCappedClean = integerCapped
             .replace(TUI_NON_DIGITS_REGEXP, '')
             .replace(/^0+(?!\.|$)/, '0');
-        const withSeparator = addThousandsSeparator(integerCappedClean);
+        const withSeparator = addThousandsSeparator(integerCappedClean, thousandSymbol);
         const mask = convertToMask(withSeparator);
 
         if ((hasDecimal && allowDecimal) || requireDecimal) {
@@ -155,8 +153,8 @@ function convertToMask(strNumber: string): Array<string | RegExp> {
         .map(char => (TUI_DIGIT_REGEXP.test(char) ? TUI_DIGIT_REGEXP : char));
 }
 
-function addThousandsSeparator(strNumber: string): string {
+function addThousandsSeparator(strNumber: string, thousandSymbol: string): string {
     return strNumber.length > 3
-        ? strNumber.replace(/\B(?=(\d{3})+(?!\d))/g, CHAR_NO_BREAK_SPACE)
+        ? strNumber.replace(/\B(?=(\d{3})+(?!\d))/g, thousandSymbol)
         : strNumber;
 }

--- a/projects/core/utils/mask/masked-number-string-to-number.ts
+++ b/projects/core/utils/mask/masked-number-string-to-number.ts
@@ -1,9 +1,11 @@
-import { TuiDecimalSymbol } from "@taiga-ui/core/types";
+import {TuiDecimalSymbol} from '@taiga-ui/core/types';
 
 export function maskedNumberStringToNumber(
     value: string,
     decimalsSymbol: TuiDecimalSymbol,
     thousandSymbol: string,
 ): number {
-    return parseFloat(value.split(thousandSymbol).join('').split(decimalsSymbol).join('.'));
+    return parseFloat(
+        value.split(thousandSymbol).join('').split(decimalsSymbol).join('.'),
+    );
 }

--- a/projects/core/utils/mask/masked-number-string-to-number.ts
+++ b/projects/core/utils/mask/masked-number-string-to-number.ts
@@ -1,5 +1,9 @@
-import {CHAR_NO_BREAK_SPACE} from '@taiga-ui/cdk';
+import { TuiDecimalSymbol } from "@taiga-ui/core/types";
 
-export function maskedNumberStringToNumber(value: string): number {
-    return parseFloat(value.split(CHAR_NO_BREAK_SPACE).join('').split(',').join('.'));
+export function maskedNumberStringToNumber(
+    value: string,
+    decimalsSymbol: TuiDecimalSymbol,
+    thousandSymbol: string,
+): number {
+    return parseFloat(value.split(thousandSymbol).join('').split(decimalsSymbol).join('.'));
 }

--- a/projects/core/utils/mask/test/masked-number-string-to-number.spec.ts
+++ b/projects/core/utils/mask/test/masked-number-string-to-number.spec.ts
@@ -6,15 +6,23 @@ describe('Converts the text value of a number obtained from a mask into a number
         expect(
             maskedNumberStringToNumber(
                 `12${CHAR_NO_BREAK_SPACE}345${CHAR_NO_BREAK_SPACE}678`,
+                ',',
+                CHAR_NO_BREAK_SPACE,
             ),
         ).toBe(12345678);
     });
 
     it('correctly handles the fractional part', () => {
-        expect(maskedNumberStringToNumber('1,23')).toBe(1.23);
+        expect(maskedNumberStringToNumber('1,23', ',', ' ')).toBe(1.23);
+    });
+
+    it('correctly handles custom decimals and thousand symbols', () => {
+        expect(maskedNumberStringToNumber('200/000/000.50', '.', '/')).toBe(
+            200_000_000.5,
+        );
     });
 
     it('returns NaN if the string cannot be converted to a number', () => {
-        expect(maskedNumberStringToNumber('Дичь')).toBeNaN();
+        expect(maskedNumberStringToNumber('Дичь', ',', ' ')).toBeNaN();
     });
 });

--- a/projects/demo/src/modules/components/input-count/input-count.template.html
+++ b/projects/demo/src/modules/components/input-count/input-count.template.html
@@ -10,6 +10,11 @@
 
         <p i18n>It does not indicate validation status</p>
 
+        <p i18n>
+            Number formatting can be customized by using
+            <a tuiLink routerLink="/utils/tokens">TUI_NUMBER_FORMAT</a>
+        </p>
+
         <tui-doc-example
             id="base"
             i18n-heading

--- a/projects/demo/src/modules/components/input-number/input-number.template.html
+++ b/projects/demo/src/modules/components/input-number/input-number.template.html
@@ -26,6 +26,11 @@
             for inputting with a slider
         </p>
 
+        <p i18n>
+            Number formatting can be customized by using
+            <a tuiLink routerLink="/utils/tokens">TUI_NUMBER_FORMAT</a>
+        </p>
+
         <tui-doc-example
             id="currency"
             i18n-heading

--- a/projects/demo/src/modules/components/input-range/input-range.module.ts
+++ b/projects/demo/src/modules/components/input-range/input-range.module.ts
@@ -3,7 +3,7 @@ import {NgModule} from '@angular/core';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {RouterModule} from '@angular/router';
 import {generateRoutes, TuiAddonDocModule} from '@taiga-ui/addon-doc';
-import {TuiButtonModule} from '@taiga-ui/core';
+import {TuiButtonModule, TuiLinkModule} from '@taiga-ui/core';
 import {
     TuiInputRangeModule,
     TuiInputSliderModule,
@@ -24,6 +24,7 @@ import {ExampleTuiInputRangeComponent} from './input-range.component';
         TuiRadioListModule,
         TuiAddonDocModule,
         TuiButtonModule,
+        TuiLinkModule,
         RouterModule.forChild(generateRoutes(ExampleTuiInputRangeComponent)),
     ],
     declarations: [ExampleTuiInputRangeComponent, TuiInputRangeExample1],

--- a/projects/demo/src/modules/components/input-range/input-range.template.html
+++ b/projects/demo/src/modules/components/input-range/input-range.template.html
@@ -2,6 +2,11 @@
     <ng-template pageTab>
         <p i18n>Component to input a range of values</p>
 
+        <p i18n>
+            Number formatting can be customized by using
+            <a tuiLink routerLink="/utils/tokens">TUI_NUMBER_FORMAT</a>
+        </p>
+
         <tui-doc-example
             id="base"
             i18n-heading

--- a/projects/demo/src/modules/components/input-slider/input-slider.template.html
+++ b/projects/demo/src/modules/components/input-slider/input-slider.template.html
@@ -2,6 +2,11 @@
     <ng-template pageTab>
         <p i18n>Component to input a limited range</p>
 
+        <p i18n>
+            Number formatting can be customized by using
+            <a tuiLink routerLink="/utils/tokens">TUI_NUMBER_FORMAT</a>
+        </p>
+
         <tui-doc-example
             id="base"
             i18n-heading

--- a/projects/demo/src/modules/components/money/money.module.ts
+++ b/projects/demo/src/modules/components/money/money.module.ts
@@ -4,6 +4,7 @@ import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {RouterModule} from '@angular/router';
 import {TuiMoneyModule} from '@taiga-ui/addon-commerce';
 import {generateRoutes, TuiAddonDocModule} from '@taiga-ui/addon-doc';
+import {TuiLinkModule} from '@taiga-ui/core';
 import {TuiRadioListModule} from '@taiga-ui/kit';
 import {TuiMoneyExample1} from './examples/1';
 import {TuiMoneyExample2} from './examples/2';
@@ -19,6 +20,7 @@ import {ExampleTuiMoneyComponent} from './money.component';
         ReactiveFormsModule,
         CommonModule,
         TuiAddonDocModule,
+        TuiLinkModule,
         RouterModule.forChild(generateRoutes(ExampleTuiMoneyComponent)),
     ],
     declarations: [

--- a/projects/demo/src/modules/components/money/money.template.html
+++ b/projects/demo/src/modules/components/money/money.template.html
@@ -10,6 +10,11 @@
             used in a text
         </p>
 
+        <p i18n>
+            Number formatting can be customized by using
+            <a tuiLink routerLink="/utils/tokens">TUI_NUMBER_FORMAT</a>
+        </p>
+
         <tui-doc-example
             id="currency"
             i18n-heading

--- a/projects/demo/src/modules/pipes/format-number/format-number.module.ts
+++ b/projects/demo/src/modules/pipes/format-number/format-number.module.ts
@@ -3,7 +3,7 @@ import {NgModule} from '@angular/core';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {RouterModule} from '@angular/router';
 import {generateRoutes, TuiAddonDocModule} from '@taiga-ui/addon-doc';
-import {TuiFormatNumberPipeModule} from '@taiga-ui/core';
+import {TuiFormatNumberPipeModule, TuiLinkModule} from '@taiga-ui/core';
 import {TuiInputSliderModule, TuiRadioListModule} from '@taiga-ui/kit';
 import {TuiFormatNumberExample1} from './examples/1';
 import {ExampleTuiFormatNumberComponent} from './format-number.component';
@@ -17,6 +17,7 @@ import {ExampleTuiFormatNumberComponent} from './format-number.component';
         CommonModule,
         TuiRadioListModule,
         TuiAddonDocModule,
+        TuiLinkModule,
         RouterModule.forChild(generateRoutes(ExampleTuiFormatNumberComponent)),
     ],
     declarations: [ExampleTuiFormatNumberComponent, TuiFormatNumberExample1],

--- a/projects/demo/src/modules/pipes/format-number/format-number.template.html
+++ b/projects/demo/src/modules/pipes/format-number/format-number.template.html
@@ -2,6 +2,11 @@
     <ng-template pageTab>
         <p i18n>Pipe to format number values to separate thousands</p>
 
+        <p i18n>
+            Number formatting can be customized by using
+            <a tuiLink routerLink="/utils/tokens">TUI_NUMBER_FORMAT</a>
+        </p>
+
         <tui-doc-example
             id="base"
             i18n-heading

--- a/projects/demo/src/modules/utils/tokens/examples/8/index.html
+++ b/projects/demo/src/modules/utils/tokens/examples/8/index.html
@@ -1,0 +1,42 @@
+<div i18n>
+    <div>
+        Using <strong>TUI_NUMBER_FORMAT</strong> injection token you can
+        customize numbers formatting.
+    </div>
+    <div>For example: 10 500,33</div>
+    <div>Can be customized as: 10/500.33</div>
+    <p></p>
+    <div>
+        <strong>Defaults:</strong>
+    </div>
+    <div>decimalSeparator = ','</div>
+    <div>thousandSeparator = CHAR_NO_BREAK_SPACE</div>
+    <p></p>
+    <div>
+        <strong>Components that are customizable:</strong>
+    </div>
+    <div><a tuiLink routerLink="/components/money">TuiMoneyComponent</a></div>
+    <div>
+        <a tuiLink routerLink="/components/input-slider"
+            >TuiInputSliderComponent</a
+        >
+    </div>
+    <div>
+        <a tuiLink routerLink="/components/input-range"
+            >TuiInputRangeComponent</a
+        >
+    </div>
+    <div>
+        <a tuiLink routerLink="/components/input-number"
+            >TuiInputNumberComponent</a
+        >
+    </div>
+    <div>
+        <a tuiLink routerLink="/components/input-count"
+            >TuiInputCountComponent</a
+        >
+    </div>
+    <div>
+        <a tuiLink routerLink="/pipes/format-number">TuiFormatNumberPipe</a>
+    </div>
+</div>

--- a/projects/demo/src/modules/utils/tokens/examples/8/index.ts
+++ b/projects/demo/src/modules/utils/tokens/examples/8/index.ts
@@ -1,0 +1,17 @@
+import {Component, Inject} from '@angular/core';
+import {NumberFormatSettings, TUI_NUMBER_FORMAT} from '@taiga-ui/core';
+import {changeDetection} from '../../../../../change-detection-strategy';
+import {encapsulation} from '../../../../../view-encapsulation';
+
+@Component({
+    selector: 'tui-token-example-8',
+    templateUrl: './index.html',
+    changeDetection,
+    encapsulation,
+})
+export class TuiTokensExample8 {
+    constructor(
+        @Inject(TUI_NUMBER_FORMAT)
+        readonly numberFormatSettings: NumberFormatSettings,
+    ) {}
+}

--- a/projects/demo/src/modules/utils/tokens/tokens.component.ts
+++ b/projects/demo/src/modules/utils/tokens/tokens.component.ts
@@ -19,6 +19,9 @@ import {default as example6Ts} from '!!raw-loader!./examples/6/index.ts';
 import {default as example7Html} from '!!raw-loader!./examples/7/index.html';
 import {default as example7Ts} from '!!raw-loader!./examples/7/index.ts';
 
+import {default as example8Html} from '!!raw-loader!./examples/8/index.html';
+import {default as example8Ts} from '!!raw-loader!./examples/8/index.ts';
+
 import {Component} from '@angular/core';
 import {changeDetection} from '../../../change-detection-strategy';
 import {FrontEndExample} from '../../interfaces/front-end-example';
@@ -62,5 +65,10 @@ export class ExampleTokensComponent {
     readonly example7: FrontEndExample = {
         TypeScript: example7Ts,
         HTML: example7Html,
+    };
+
+    readonly example8: FrontEndExample = {
+        TypeScript: example8Ts,
+        HTML: example8Html,
     };
 }

--- a/projects/demo/src/modules/utils/tokens/tokens.module.ts
+++ b/projects/demo/src/modules/utils/tokens/tokens.module.ts
@@ -10,6 +10,7 @@ import {TuiTokensExample4} from './examples/4';
 import {TuiTokensExample5} from './examples/5';
 import {TuiTokensExample6} from './examples/6';
 import {TuiTokensExample7} from './examples/7';
+import {TuiTokensExample8} from './examples/8';
 import {ExampleTokensComponent} from './tokens.component';
 
 @NgModule({
@@ -28,6 +29,7 @@ import {ExampleTokensComponent} from './tokens.component';
         TuiTokensExample5,
         TuiTokensExample6,
         TuiTokensExample7,
+        TuiTokensExample8,
     ],
     exports: [ExampleTokensComponent],
 })

--- a/projects/demo/src/modules/utils/tokens/tokens.template.html
+++ b/projects/demo/src/modules/utils/tokens/tokens.template.html
@@ -39,5 +39,13 @@
         >
             <tui-token-example-6></tui-token-example-6>
         </tui-doc-example>
+
+        <tui-doc-example
+            id="number-format"
+            heading="TUI_NUMBER_FORMAT"
+            [content]="example8"
+        >
+            <tui-token-example-8></tui-token-example-8>
+        </tui-doc-example>
     </ng-template>
 </tui-doc-page>

--- a/projects/kit/abstract/input-slider.ts
+++ b/projects/kit/abstract/input-slider.ts
@@ -9,6 +9,7 @@ import {
 } from '@taiga-ui/cdk';
 import {
     maskedNumberStringToNumber,
+    NumberFormatSettings,
     TuiBrightness,
     tuiCreateAutoCorrectedNumberPipe,
     tuiCreateNumberMask,
@@ -19,7 +20,6 @@ import {
     TuiTextMaskOptions,
     TuiWithOptionalMinMax,
 } from '@taiga-ui/core';
-import {NumberFormatSettings} from '@taiga-ui/core/interfaces/number-format-settings';
 import {TUI_FLOATING_PRECISION} from '@taiga-ui/kit/constants';
 import {TuiKeySteps} from '@taiga-ui/kit/types';
 
@@ -87,13 +87,13 @@ export abstract class AbstractTuiInputSlider<T>
         mask: tuiCreateNumberMask({
             allowNegative: min < 0,
             allowDecimal: !Number.isInteger(quantum),
-            decimalSymbol: this.numberFormatSettings.decimalSeparator,
-            thousandSymbol: this.numberFormatSettings.thousandSeparator,
+            decimalSymbol: this.numberFormat.decimalSeparator,
+            thousandSymbol: this.numberFormat.thousandSeparator,
         }),
         pipe: tuiCreateAutoCorrectedNumberPipe(
             0,
-            this.numberFormatSettings.decimalSeparator,
-            this.numberFormatSettings.thousandSeparator,
+            this.numberFormat.decimalSeparator,
+            this.numberFormat.thousandSeparator,
         ),
         guide: false,
     });
@@ -102,7 +102,7 @@ export abstract class AbstractTuiInputSlider<T>
 
     protected abstract readonly modeDirective: TuiModeDirective | null;
 
-    protected abstract readonly numberFormatSettings: NumberFormatSettings;
+    protected abstract readonly numberFormat: NumberFormatSettings;
 
     @HostBinding('class._segmented')
     get segmented(): boolean {
@@ -159,8 +159,8 @@ export abstract class AbstractTuiInputSlider<T>
         const capped = Math.min(
             maskedNumberStringToNumber(
                 value,
-                this.numberFormatSettings.decimalSeparator,
-                this.numberFormatSettings.thousandSeparator,
+                this.numberFormat.decimalSeparator,
+                this.numberFormat.thousandSeparator,
             ),
             max,
         );

--- a/projects/kit/abstract/input-slider.ts
+++ b/projects/kit/abstract/input-slider.ts
@@ -19,6 +19,7 @@ import {
     TuiTextMaskOptions,
     TuiWithOptionalMinMax,
 } from '@taiga-ui/core';
+import {NumberFormatSettings} from '@taiga-ui/core/interfaces/number-format-settings';
 import {TUI_FLOATING_PRECISION} from '@taiga-ui/kit/constants';
 import {TuiKeySteps} from '@taiga-ui/kit/types';
 
@@ -86,14 +87,22 @@ export abstract class AbstractTuiInputSlider<T>
         mask: tuiCreateNumberMask({
             allowNegative: min < 0,
             allowDecimal: !Number.isInteger(quantum),
+            decimalSymbol: this.numberFormatSettings.decimalSeparator,
+            thousandSymbol: this.numberFormatSettings.thousandSeparator,
         }),
-        pipe: tuiCreateAutoCorrectedNumberPipe(),
+        pipe: tuiCreateAutoCorrectedNumberPipe(
+            0,
+            this.numberFormatSettings.decimalSeparator,
+            this.numberFormatSettings.thousandSeparator,
+        ),
         guide: false,
     });
 
     pluralizeMap: Record<string, string> | null = null;
 
     protected abstract readonly modeDirective: TuiModeDirective | null;
+
+    protected abstract readonly numberFormatSettings: NumberFormatSettings;
 
     @HostBinding('class._segmented')
     get segmented(): boolean {
@@ -147,7 +156,14 @@ export abstract class AbstractTuiInputSlider<T>
     }
 
     protected capInputValue(value: string, max: number = this.max): number | null {
-        const capped = Math.min(maskedNumberStringToNumber(value), max);
+        const capped = Math.min(
+            maskedNumberStringToNumber(
+                value,
+                this.numberFormatSettings.decimalSeparator,
+                this.numberFormatSettings.thousandSeparator,
+            ),
+            max,
+        );
 
         if (this.min < 0 && capped < this.min) {
             return this.min;

--- a/projects/kit/components/input-count/input-count.component.ts
+++ b/projects/kit/components/input-count/input-count.component.ts
@@ -25,6 +25,8 @@ import {
 } from '@taiga-ui/cdk';
 import {
     formatNumber,
+    NumberFormatSettings,
+    TUI_NUMBER_FORMAT,
     TUI_TEXTFIELD_APPEARANCE,
     TUI_TEXTFIELD_SIZE,
     TuiAppearance,
@@ -36,8 +38,6 @@ import {
     TuiTextMaskOptions,
     TuiWithOptionalMinMax,
 } from '@taiga-ui/core';
-import {NumberFormatSettings} from '@taiga-ui/core/interfaces/number-format-settings';
-import {TUI_NUMBER_FORMAT} from '@taiga-ui/core/tokens/number-format';
 import {TUI_PLUS_MINUS_TEXTS} from '@taiga-ui/kit/tokens';
 import {Observable} from 'rxjs';
 
@@ -82,8 +82,8 @@ export class TuiInputCountComponent
         return {
             mask: tuiCreateNumberMask({
                 allowNegative,
-                decimalSymbol: this.numberFormatSettings.decimalSeparator,
-                thousandSymbol: this.numberFormatSettings.thousandSeparator,
+                decimalSymbol: this.numberFormat.decimalSeparator,
+                thousandSymbol: this.numberFormat.thousandSeparator,
             }),
             guide: false,
         };
@@ -106,7 +106,7 @@ export class TuiInputCountComponent
         readonly minusTexts$: Observable<[string, string]>,
         @Inject(TUI_IS_MOBILE) private readonly isMobile: boolean,
         @Inject(TUI_NUMBER_FORMAT)
-        protected readonly numberFormatSettings: NumberFormatSettings,
+        private readonly numberFormat: NumberFormatSettings,
     ) {
         super(control, changeDetectorRef);
     }
@@ -239,7 +239,7 @@ export class TuiInputCountComponent
 
     private get nativeNumberValue(): number {
         return parseInt(
-            this.nativeValue.split(this.numberFormatSettings.thousandSeparator).join(''),
+            this.nativeValue.split(this.numberFormat.thousandSeparator).join(''),
             10,
         );
     }
@@ -285,8 +285,8 @@ export class TuiInputCountComponent
         return formatNumber(
             value,
             null,
-            this.numberFormatSettings.decimalSeparator,
-            this.numberFormatSettings.thousandSeparator,
+            this.numberFormat.decimalSeparator,
+            this.numberFormat.thousandSeparator,
         );
     }
 }

--- a/projects/kit/components/input-count/input-count.component.ts
+++ b/projects/kit/components/input-count/input-count.component.ts
@@ -13,7 +13,6 @@ import {
 import {NgControl} from '@angular/forms';
 import {
     AbstractTuiControl,
-    CHAR_NO_BREAK_SPACE,
     clamp,
     isNativeFocused,
     isPresent,
@@ -37,6 +36,8 @@ import {
     TuiTextMaskOptions,
     TuiWithOptionalMinMax,
 } from '@taiga-ui/core';
+import {NumberFormatSettings} from '@taiga-ui/core/interfaces/number-format-settings';
+import {TUI_NUMBER_FORMAT} from '@taiga-ui/core/tokens/number-format';
 import {TUI_PLUS_MINUS_TEXTS} from '@taiga-ui/kit/tokens';
 import {Observable} from 'rxjs';
 
@@ -78,7 +79,14 @@ export class TuiInputCountComponent
 
     @tuiPure
     getMask(allowNegative: boolean): TuiTextMaskOptions {
-        return {mask: tuiCreateNumberMask({allowNegative}), guide: false};
+        return {
+            mask: tuiCreateNumberMask({
+                allowNegative,
+                decimalSymbol: this.numberFormatSettings.decimalSeparator,
+                thousandSymbol: this.numberFormatSettings.thousandSeparator,
+            }),
+            guide: false,
+        };
     }
 
     @ViewChild(TuiPrimitiveTextfieldComponent)
@@ -97,6 +105,8 @@ export class TuiInputCountComponent
         @Inject(TUI_PLUS_MINUS_TEXTS)
         readonly minusTexts$: Observable<[string, string]>,
         @Inject(TUI_IS_MOBILE) private readonly isMobile: boolean,
+        @Inject(TUI_NUMBER_FORMAT)
+        protected readonly numberFormatSettings: NumberFormatSettings,
     ) {
         super(control, changeDetectorRef);
     }
@@ -126,7 +136,7 @@ export class TuiInputCountComponent
     }
 
     get computedValue(): string {
-        return formatNumber(this.value);
+        return this.formatNumber(this.value);
     }
 
     get minusButtonDisabled(): boolean {
@@ -177,7 +187,7 @@ export class TuiInputCountComponent
             return;
         }
 
-        const newValue = formatNumber(capped);
+        const newValue = this.formatNumber(capped);
 
         if (this.nativeValue !== newValue) {
             this.nativeValue = newValue;
@@ -228,7 +238,10 @@ export class TuiInputCountComponent
     }
 
     private get nativeNumberValue(): number {
-        return parseInt(this.nativeValue.split(CHAR_NO_BREAK_SPACE).join(''), 10);
+        return parseInt(
+            this.nativeValue.split(this.numberFormatSettings.thousandSeparator).join(''),
+            10,
+        );
     }
 
     private get nativeValue(): string {
@@ -247,7 +260,7 @@ export class TuiInputCountComponent
         const value = clamp(newValue, this.min, this.max);
 
         this.updateValue(value);
-        this.nativeValue = formatNumber(value);
+        this.nativeValue = this.formatNumber(value);
     }
 
     private capValue(value: number): number | null {
@@ -258,7 +271,7 @@ export class TuiInputCountComponent
 
     private onBlur() {
         const value = Math.max(this.nativeNumberValue || 0, this.min);
-        const formattedValue = formatNumber(value);
+        const formattedValue = this.formatNumber(value);
 
         this.nativeValue = formattedValue;
         this.updateValue(value);
@@ -266,5 +279,14 @@ export class TuiInputCountComponent
         if (this.primitiveTextfield) {
             this.primitiveTextfield.value = formattedValue;
         }
+    }
+
+    private formatNumber(value: number): string {
+        return formatNumber(
+            value,
+            null,
+            this.numberFormatSettings.decimalSeparator,
+            this.numberFormatSettings.thousandSeparator,
+        );
     }
 }

--- a/projects/kit/components/input-number/input-number.component.ts
+++ b/projects/kit/components/input-number/input-number.component.ts
@@ -23,15 +23,15 @@ import {
     formatNumber,
     maskedMoneyValueIsEmpty,
     maskedNumberStringToNumber,
+    NumberFormatSettings,
+    TUI_DECIMAL_SYMBOLS,
+    TUI_NUMBER_FORMAT,
     tuiCreateAutoCorrectedNumberPipe,
     tuiCreateNumberMask,
     TuiDecimalT,
     TuiPrimitiveTextfieldComponent,
     TuiTextMaskOptions,
 } from '@taiga-ui/core';
-import {TUI_DECIMAL_SYMBOLS} from '@taiga-ui/core/constants/decimal-symbols';
-import {NumberFormatSettings} from '@taiga-ui/core/interfaces/number-format-settings';
-import {TUI_NUMBER_FORMAT} from '@taiga-ui/core/tokens/number-format';
 
 const DEFAULT_MAX_LENGTH = 18;
 
@@ -82,13 +82,13 @@ export class TuiInputNumberComponent
             allowDecimal: decimal !== 'never',
             decimalLimit: precision,
             requireDecimal: decimal === 'always',
-            decimalSymbol: this.numberFormatSettings.decimalSeparator,
-            thousandSymbol: this.numberFormatSettings.thousandSeparator,
+            decimalSymbol: this.numberFormat.decimalSeparator,
+            thousandSymbol: this.numberFormat.thousandSeparator,
         }),
         pipe: tuiCreateAutoCorrectedNumberPipe(
             decimal === 'always' ? precision : 0,
-            this.numberFormatSettings.decimalSeparator,
-            this.numberFormatSettings.thousandSeparator,
+            this.numberFormat.decimalSeparator,
+            this.numberFormat.thousandSeparator,
             nativeFocusableElement || undefined,
         ),
         guide: false,
@@ -105,7 +105,7 @@ export class TuiInputNumberComponent
         @Inject(ChangeDetectorRef)
         changeDetectorRef: ChangeDetectorRef,
         @Inject(TUI_NUMBER_FORMAT)
-        private numberFormatSettings: NumberFormatSettings,
+        private readonly numberFormat: NumberFormatSettings,
     ) {
         super(control, changeDetectorRef);
     }
@@ -132,7 +132,7 @@ export class TuiInputNumberComponent
         return (
             DEFAULT_MAX_LENGTH +
             (this.decimal !== 'never' &&
-            this.nativeValue.includes(this.numberFormatSettings.decimalSeparator)
+            this.nativeValue.includes(this.numberFormat.decimalSeparator)
                 ? this.precision + 1
                 : 0)
         );
@@ -155,8 +155,8 @@ export class TuiInputNumberComponent
         return formatNumber(
             value,
             limit,
-            this.numberFormatSettings.decimalSeparator,
-            this.numberFormatSettings.thousandSeparator,
+            this.numberFormat.decimalSeparator,
+            this.numberFormat.thousandSeparator,
         );
     }
 
@@ -195,8 +195,8 @@ export class TuiInputNumberComponent
             capped !==
             maskedNumberStringToNumber(
                 value,
-                this.numberFormatSettings.decimalSeparator,
-                this.numberFormatSettings.thousandSeparator
+                this.numberFormat.decimalSeparator,
+                this.numberFormat.thousandSeparator,
             )
         ) {
             this.nativeValue = this.formattedValue;
@@ -204,7 +204,7 @@ export class TuiInputNumberComponent
     }
 
     onKeyDown(event: KeyboardEvent) {
-        if (!TUI_DECIMAL_SYMBOLS.includes(event.key)) {
+        if (TUI_DECIMAL_SYMBOLS.indexOf(event.key) === -1) {
             return;
         }
 
@@ -214,7 +214,7 @@ export class TuiInputNumberComponent
             return;
         }
 
-        if (this.nativeValue.includes(this.numberFormatSettings.decimalSeparator)) {
+        if (this.nativeValue.includes(this.numberFormat.decimalSeparator)) {
             event.preventDefault();
             this.setCaretAfterComma();
         }
@@ -252,7 +252,7 @@ export class TuiInputNumberComponent
     @HostListener('keydown.0', ['$event'])
     onZero(event: KeyboardEvent) {
         const decimal =
-            this.nativeValue.split(this.numberFormatSettings.decimalSeparator)[1] || '';
+            this.nativeValue.split(this.numberFormat.decimalSeparator)[1] || '';
         const {nativeFocusableElement} = this;
 
         if (
@@ -293,8 +293,8 @@ export class TuiInputNumberComponent
     private get nativeNumberValue(): number {
         return maskedNumberStringToNumber(
             this.nativeValue,
-            this.numberFormatSettings.decimalSeparator,
-            this.numberFormatSettings.thousandSeparator,
+            this.numberFormat.decimalSeparator,
+            this.numberFormat.thousandSeparator,
         );
     }
 
@@ -315,8 +315,8 @@ export class TuiInputNumberComponent
     private absoluteCapInputValue(inputValue: string): number | null {
         const value = maskedNumberStringToNumber(
             inputValue,
-            this.numberFormatSettings.decimalSeparator,
-            this.numberFormatSettings.thousandSeparator,
+            this.numberFormat.decimalSeparator,
+            this.numberFormat.thousandSeparator,
         );
         const capped = value < 0 ? Math.max(this.min, value) : Math.min(value, this.max);
         const ineligibleValue = isNaN(capped) || capped < this.min || capped > this.max;

--- a/projects/kit/components/input-number/input-number.component.ts
+++ b/projects/kit/components/input-number/input-number.component.ts
@@ -29,6 +29,9 @@ import {
     TuiPrimitiveTextfieldComponent,
     TuiTextMaskOptions,
 } from '@taiga-ui/core';
+import {TUI_DECIMAL_SYMBOLS} from '@taiga-ui/core/constants/decimal-symbols';
+import {NumberFormatSettings} from '@taiga-ui/core/interfaces/number-format-settings';
+import {TUI_NUMBER_FORMAT} from '@taiga-ui/core/tokens/number-format';
 
 const DEFAULT_MAX_LENGTH = 18;
 
@@ -79,10 +82,13 @@ export class TuiInputNumberComponent
             allowDecimal: decimal !== 'never',
             decimalLimit: precision,
             requireDecimal: decimal === 'always',
+            decimalSymbol: this.numberFormatSettings.decimalSeparator,
+            thousandSymbol: this.numberFormatSettings.thousandSeparator,
         }),
         pipe: tuiCreateAutoCorrectedNumberPipe(
             decimal === 'always' ? precision : 0,
-            ',',
+            this.numberFormatSettings.decimalSeparator,
+            this.numberFormatSettings.thousandSeparator,
             nativeFocusableElement || undefined,
         ),
         guide: false,
@@ -96,7 +102,10 @@ export class TuiInputNumberComponent
         @Self()
         @Inject(NgControl)
         control: NgControl | null,
-        @Inject(ChangeDetectorRef) changeDetectorRef: ChangeDetectorRef,
+        @Inject(ChangeDetectorRef)
+        changeDetectorRef: ChangeDetectorRef,
+        @Inject(TUI_NUMBER_FORMAT)
+        private numberFormatSettings: NumberFormatSettings,
     ) {
         super(control, changeDetectorRef);
     }
@@ -122,7 +131,8 @@ export class TuiInputNumberComponent
     get calculatedMaxLength(): number {
         return (
             DEFAULT_MAX_LENGTH +
-            (this.decimal !== 'never' && this.nativeValue.includes(',')
+            (this.decimal !== 'never' &&
+            this.nativeValue.includes(this.numberFormatSettings.decimalSeparator)
                 ? this.precision + 1
                 : 0)
         );
@@ -142,7 +152,12 @@ export class TuiInputNumberComponent
             limit = fraction.length;
         }
 
-        return formatNumber(value, limit);
+        return formatNumber(
+            value,
+            limit,
+            this.numberFormatSettings.decimalSeparator,
+            this.numberFormatSettings.thousandSeparator,
+        );
     }
 
     get computedValue(): string {
@@ -176,13 +191,20 @@ export class TuiInputNumberComponent
 
         this.updateValue(capped);
 
-        if (capped !== maskedNumberStringToNumber(value)) {
+        if (
+            capped !==
+            maskedNumberStringToNumber(
+                value,
+                this.numberFormatSettings.decimalSeparator,
+                this.numberFormatSettings.thousandSeparator
+            )
+        ) {
             this.nativeValue = this.formattedValue;
         }
     }
 
     onKeyDown(event: KeyboardEvent) {
-        if (event.key !== ',' && event.key !== '.') {
+        if (!TUI_DECIMAL_SYMBOLS.includes(event.key)) {
             return;
         }
 
@@ -192,7 +214,7 @@ export class TuiInputNumberComponent
             return;
         }
 
-        if (this.nativeValue.includes(',')) {
+        if (this.nativeValue.includes(this.numberFormatSettings.decimalSeparator)) {
             event.preventDefault();
             this.setCaretAfterComma();
         }
@@ -205,7 +227,7 @@ export class TuiInputNumberComponent
             return;
         }
 
-        const nativeNumberValue = maskedNumberStringToNumber(this.nativeValue);
+        const nativeNumberValue = this.nativeNumberValue;
 
         if (isNaN(nativeNumberValue)) {
             this.clear();
@@ -229,7 +251,8 @@ export class TuiInputNumberComponent
 
     @HostListener('keydown.0', ['$event'])
     onZero(event: KeyboardEvent) {
-        const decimal = this.nativeValue.split(',')[1] || '';
+        const decimal =
+            this.nativeValue.split(this.numberFormatSettings.decimalSeparator)[1] || '';
         const {nativeFocusableElement} = this;
 
         if (
@@ -250,13 +273,13 @@ export class TuiInputNumberComponent
             return true;
         }
 
-        const nativeNumberValue = maskedNumberStringToNumber(this.nativeValue);
+        const nativeNumberValue = this.nativeNumberValue;
 
         return nativeNumberValue >= this.min && nativeNumberValue <= this.max;
     }
 
     private get isNativeValueNotFinished(): boolean {
-        const nativeNumberValue = maskedNumberStringToNumber(this.nativeValue);
+        const nativeNumberValue = this.nativeNumberValue;
 
         return nativeNumberValue < 0
             ? nativeNumberValue > this.max
@@ -265,6 +288,14 @@ export class TuiInputNumberComponent
 
     private get nativeValue(): string {
         return this.nativeFocusableElement ? this.nativeFocusableElement.value : '';
+    }
+
+    private get nativeNumberValue(): number {
+        return maskedNumberStringToNumber(
+            this.nativeValue,
+            this.numberFormatSettings.decimalSeparator,
+            this.numberFormatSettings.thousandSeparator,
+        );
     }
 
     private set nativeValue(value: string) {
@@ -282,7 +313,11 @@ export class TuiInputNumberComponent
     }
 
     private absoluteCapInputValue(inputValue: string): number | null {
-        const value = maskedNumberStringToNumber(inputValue);
+        const value = maskedNumberStringToNumber(
+            inputValue,
+            this.numberFormatSettings.decimalSeparator,
+            this.numberFormatSettings.thousandSeparator,
+        );
         const capped = value < 0 ? Math.max(this.min, value) : Math.min(value, this.max);
         const ineligibleValue = isNaN(capped) || capped < this.min || capped > this.max;
 

--- a/projects/kit/components/input-range/input-range.component.ts
+++ b/projects/kit/components/input-range/input-range.component.ts
@@ -23,10 +23,10 @@ import {
     formatNumber,
     maskedMoneyValueIsEmpty,
     maskedNumberStringToNumber,
+    NumberFormatSettings,
+    TUI_NUMBER_FORMAT,
     TuiModeDirective,
 } from '@taiga-ui/core';
-import {NumberFormatSettings} from '@taiga-ui/core/interfaces/number-format-settings';
-import {TUI_NUMBER_FORMAT} from '@taiga-ui/core/tokens/number-format';
 import {AbstractTuiInputSlider} from '@taiga-ui/kit/abstract';
 
 // @dynamic
@@ -63,7 +63,7 @@ export class TuiInputRangeComponent
         @Inject(TUI_IS_MOBILE)
         private readonly isMobile: boolean,
         @Inject(TUI_NUMBER_FORMAT)
-        protected readonly numberFormatSettings: NumberFormatSettings,
+        protected readonly numberFormat: NumberFormatSettings,
     ) {
         super(control, changeDetectorRef);
     }
@@ -225,8 +225,8 @@ export class TuiInputRangeComponent
 
         const inputValue = maskedNumberStringToNumber(
             this.computedValueLeft,
-            this.numberFormatSettings.decimalSeparator,
-            this.numberFormatSettings.thousandSeparator,
+            this.numberFormat.decimalSeparator,
+            this.numberFormat.thousandSeparator,
         );
         const value = isNaN(inputValue) ? this.min : this.valueGuard(inputValue);
 
@@ -244,8 +244,8 @@ export class TuiInputRangeComponent
 
         const inputValue = maskedNumberStringToNumber(
             this.computedValueRight,
-            this.numberFormatSettings.decimalSeparator,
-            this.numberFormatSettings.thousandSeparator,
+            this.numberFormat.decimalSeparator,
+            this.numberFormat.thousandSeparator,
         );
 
         const value = isNaN(inputValue)
@@ -267,8 +267,8 @@ export class TuiInputRangeComponent
         return formatNumber(
             value,
             null,
-            this.numberFormatSettings.decimalSeparator,
-            this.numberFormatSettings.thousandSeparator,
+            this.numberFormat.decimalSeparator,
+            this.numberFormat.thousandSeparator,
         );
     }
 

--- a/projects/kit/components/input-range/input-range.component.ts
+++ b/projects/kit/components/input-range/input-range.component.ts
@@ -25,6 +25,8 @@ import {
     maskedNumberStringToNumber,
     TuiModeDirective,
 } from '@taiga-ui/core';
+import {NumberFormatSettings} from '@taiga-ui/core/interfaces/number-format-settings';
+import {TUI_NUMBER_FORMAT} from '@taiga-ui/core/tokens/number-format';
 import {AbstractTuiInputSlider} from '@taiga-ui/kit/abstract';
 
 // @dynamic
@@ -58,7 +60,10 @@ export class TuiInputRangeComponent
         @Optional()
         @Inject(TuiModeDirective)
         protected readonly modeDirective: TuiModeDirective | null,
-        @Inject(TUI_IS_MOBILE) private readonly isMobile: boolean,
+        @Inject(TUI_IS_MOBILE)
+        private readonly isMobile: boolean,
+        @Inject(TUI_NUMBER_FORMAT)
+        protected readonly numberFormatSettings: NumberFormatSettings,
     ) {
         super(control, changeDetectorRef);
     }
@@ -98,11 +103,11 @@ export class TuiInputRangeComponent
     }
 
     get computedValueLeft(): string {
-        return formatNumber(this.value[0]);
+        return this.formatNumber(this.value[0]);
     }
 
     get computedValueRight(): string {
-        return formatNumber(this.value[1]);
+        return this.formatNumber(this.value[1]);
     }
 
     onActiveZone(active: boolean) {
@@ -160,7 +165,7 @@ export class TuiInputRangeComponent
             return;
         }
 
-        const newValue = formatNumber(capped) + postfix;
+        const newValue = this.formatNumber(capped) + postfix;
 
         if (this.nativeLeft && this.inputValueLeft !== newValue) {
             this.nativeLeft.nativeElement.value = newValue;
@@ -178,7 +183,7 @@ export class TuiInputRangeComponent
             return;
         }
 
-        const newValue = formatNumber(capped) + postfix;
+        const newValue = this.formatNumber(capped) + postfix;
 
         if (this.nativeRight && this.inputValueRight !== newValue) {
             this.nativeRight.nativeElement.value = newValue;
@@ -210,7 +215,7 @@ export class TuiInputRangeComponent
         }
 
         this.updateValue(guardedValue);
-        this.nativeLeft.nativeElement.value = formatNumber(guardedValue[0]);
+        this.nativeLeft.nativeElement.value = this.formatNumber(guardedValue[0]);
     }
 
     onLeftFocused(focused: boolean) {
@@ -218,10 +223,14 @@ export class TuiInputRangeComponent
             return;
         }
 
-        const inputValue = maskedNumberStringToNumber(this.computedValueLeft);
+        const inputValue = maskedNumberStringToNumber(
+            this.computedValueLeft,
+            this.numberFormatSettings.decimalSeparator,
+            this.numberFormatSettings.thousandSeparator,
+        );
         const value = isNaN(inputValue) ? this.min : this.valueGuard(inputValue);
 
-        this.nativeLeft.nativeElement.value = formatNumber(value);
+        this.nativeLeft.nativeElement.value = this.formatNumber(value);
 
         if (value !== this.value[0]) {
             this.updateValue([value, this.value[1]]);
@@ -233,12 +242,17 @@ export class TuiInputRangeComponent
             return;
         }
 
-        const inputValue = maskedNumberStringToNumber(this.computedValueRight);
+        const inputValue = maskedNumberStringToNumber(
+            this.computedValueRight,
+            this.numberFormatSettings.decimalSeparator,
+            this.numberFormatSettings.thousandSeparator,
+        );
+
         const value = isNaN(inputValue)
             ? this.value[0]
             : this.valueGuard(Math.max(inputValue, this.value[0]));
 
-        this.nativeRight.nativeElement.value = formatNumber(value);
+        this.nativeRight.nativeElement.value = this.formatNumber(value);
 
         if (value !== this.value[1]) {
             this.updateValue([this.value[0], value]);
@@ -247,6 +261,15 @@ export class TuiInputRangeComponent
 
     protected getFallbackValue(): [number, number] {
         return [0, 0];
+    }
+
+    private formatNumber(value: number): string {
+        return formatNumber(
+            value,
+            null,
+            this.numberFormatSettings.decimalSeparator,
+            this.numberFormatSettings.thousandSeparator,
+        );
     }
 
     private processStep(increment: boolean, right: boolean) {

--- a/projects/kit/components/input-slider/input-slider.component.ts
+++ b/projects/kit/components/input-slider/input-slider.component.ts
@@ -25,12 +25,12 @@ import {
     HINT_CONTROLLER_PROVIDER,
     maskedMoneyValueIsEmpty,
     maskedNumberStringToNumber,
+    NumberFormatSettings,
     TUI_HINT_WATCHED_CONTROLLER,
+    TUI_NUMBER_FORMAT,
     TuiHintControllerDirective,
     TuiModeDirective,
 } from '@taiga-ui/core';
-import {NumberFormatSettings} from '@taiga-ui/core/interfaces/number-format-settings';
-import {TUI_NUMBER_FORMAT} from '@taiga-ui/core/tokens/number-format';
 import {AbstractTuiInputSlider} from '@taiga-ui/kit/abstract';
 
 // @dynamic
@@ -69,7 +69,7 @@ export class TuiInputSliderComponent
         @Inject(TUI_HINT_WATCHED_CONTROLLER)
         readonly hintController: TuiHintControllerDirective,
         @Inject(TUI_NUMBER_FORMAT)
-        protected readonly numberFormatSettings: NumberFormatSettings,
+        protected readonly numberFormat: NumberFormatSettings,
     ) {
         super(control, changeDetectorRef);
     }
@@ -156,8 +156,8 @@ export class TuiInputSliderComponent
 
         const inputValue = maskedNumberStringToNumber(
             this.computedValue,
-            this.numberFormatSettings.decimalSeparator,
-            this.numberFormatSettings.thousandSeparator,
+            this.numberFormat.decimalSeparator,
+            this.numberFormat.thousandSeparator,
         );
         const value = isNaN(inputValue) ? this.min : this.valueGuard(inputValue);
 
@@ -173,7 +173,7 @@ export class TuiInputSliderComponent
             return;
         }
 
-        const newValue = formatNumber(capped) + postfix;
+        const newValue = this.formatNumber(capped) + postfix;
 
         if (value !== newValue) {
             this.inputValue = newValue;
@@ -192,12 +192,7 @@ export class TuiInputSliderComponent
     }
 
     private get formattedValue(): string {
-        return formatNumber(
-            this.value,
-            null,
-            this.numberFormatSettings.decimalSeparator,
-            this.numberFormatSettings.thousandSeparator,
-        );
+        return this.formatNumber(this.value);
     }
 
     private get isInputValueNotFinished(): boolean {
@@ -207,8 +202,8 @@ export class TuiInputSliderComponent
 
         const nativeNumberValue = maskedNumberStringToNumber(
             this.inputValue,
-            this.numberFormatSettings.decimalSeparator,
-            this.numberFormatSettings.thousandSeparator,
+            this.numberFormat.decimalSeparator,
+            this.numberFormat.thousandSeparator,
         );
 
         return nativeNumberValue < 0
@@ -224,5 +219,14 @@ export class TuiInputSliderComponent
         if (value !== this.value) {
             this.updateValue(value);
         }
+    }
+
+    private formatNumber(value: number): string {
+        return formatNumber(
+            value,
+            null,
+            this.numberFormat.decimalSeparator,
+            this.numberFormat.thousandSeparator,
+        );
     }
 }

--- a/projects/kit/components/input-slider/input-slider.component.ts
+++ b/projects/kit/components/input-slider/input-slider.component.ts
@@ -29,6 +29,8 @@ import {
     TuiHintControllerDirective,
     TuiModeDirective,
 } from '@taiga-ui/core';
+import {NumberFormatSettings} from '@taiga-ui/core/interfaces/number-format-settings';
+import {TUI_NUMBER_FORMAT} from '@taiga-ui/core/tokens/number-format';
 import {AbstractTuiInputSlider} from '@taiga-ui/kit/abstract';
 
 // @dynamic
@@ -66,6 +68,8 @@ export class TuiInputSliderComponent
         protected readonly modeDirective: TuiModeDirective | null,
         @Inject(TUI_HINT_WATCHED_CONTROLLER)
         readonly hintController: TuiHintControllerDirective,
+        @Inject(TUI_NUMBER_FORMAT)
+        protected readonly numberFormatSettings: NumberFormatSettings,
     ) {
         super(control, changeDetectorRef);
     }
@@ -150,7 +154,11 @@ export class TuiInputSliderComponent
             return;
         }
 
-        const inputValue = maskedNumberStringToNumber(this.computedValue);
+        const inputValue = maskedNumberStringToNumber(
+            this.computedValue,
+            this.numberFormatSettings.decimalSeparator,
+            this.numberFormatSettings.thousandSeparator,
+        );
         const value = isNaN(inputValue) ? this.min : this.valueGuard(inputValue);
 
         this.updateValue(value);
@@ -184,7 +192,12 @@ export class TuiInputSliderComponent
     }
 
     private get formattedValue(): string {
-        return formatNumber(this.value);
+        return formatNumber(
+            this.value,
+            null,
+            this.numberFormatSettings.decimalSeparator,
+            this.numberFormatSettings.thousandSeparator,
+        );
     }
 
     private get isInputValueNotFinished(): boolean {
@@ -192,7 +205,11 @@ export class TuiInputSliderComponent
             return true;
         }
 
-        const nativeNumberValue = maskedNumberStringToNumber(this.inputValue);
+        const nativeNumberValue = maskedNumberStringToNumber(
+            this.inputValue,
+            this.numberFormatSettings.decimalSeparator,
+            this.numberFormatSettings.thousandSeparator,
+        );
 
         return nativeNumberValue < 0
             ? nativeNumberValue > this.max


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [x] Feature
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Other... Please describe:

## What is the current behavior?
TaigaUi doesn't support customization of number formatting.
Particularly, you can't change the decimals separator symbol and the thousands separator symbol.

## What is the new behavior?
Now you can customize the number formatting using `TUI_NUMBER_FORMAT` injection token:
```
{
    decimalSeparator: '.',
    thousandSeparator: '_',
}
```

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

**Affected components:**
`TuiMoneyComponent`
`TuiInputSliderComponent`
`TuiInputRangeComponent`
`TuiInputNumberComponent`
`TuiInputCountComponent`

**Affected pipes:**
`TuiFormatNumberPipe`

**Affected functions:**
`tuiCreateAutoCorrectedNumberPipe()`
`tuiCreateNumberMask()`
`maskedNumberStringToNumber()`
`formatNumber()`
