### PR TITLE
ci: support PR previews from forks

### DIFF
--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -2,18 +2,22 @@
 # https://github.com/firebase/firebase-tools
 
 name: Deploy on PR
-'on': pull_request
+on: [pull_request_target]
+
 jobs:
     build_and_preview:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
+              with:
+                  ref: ${{ github.event.pull_request.head.ref }}
+                  repository: ${{ github.event.pull_request.head.repo.full_name }}
             - run: |
                   npm ci
                   npm run build:demo
             - uses: FirebaseExtended/action-hosting-deploy@v0
               with:
-                  repoToken: '${{ secrets.GITHUB_TOKEN }}'
-                  firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_TAIGA_UI }}'
+                  repoToken: ${{ secrets.GITHUB_TOKEN }}
+                  firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_TAIGA_UI }}
                   projectId: taiga-ui
                   expires: 1d


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [ ] Feature
-   [ ] Refactoring (no functional changes, no api changes)
-   [x] Other... Please describe: ci

## What is the current behavior?

The reason you are experiencing this behaviour is because the Invite workflow is being triggered by a pull request from a forked repository.

With the exception of GITHUB_TOKEN, secrets are not passed to the runner when a workflow is triggered from a forked repository.

When this happens, the actor of the workflow is the user that opened the pull request. If that user doesn't have write access to your repository then they cannot use secrets (other than GITHUB_TOKEN).

Closes #762

## What is the new behavior?

- If your repository is private, you can now enable workflows from forks.

- If your repository is public, there is a new `pull_request_target` event that is not subject to any token restrictions.

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No
