### PR TITLE
fix(kit): `ProgressCircle` keeps css-property `r` while --prod build

### DIFF
--- a/projects/kit/components/progress/progress-circle/progress-circle.style.less
+++ b/projects/kit/components/progress/progress-circle/progress-circle.style.less
@@ -27,7 +27,9 @@
     height: @width[ @@size];
 
     .t-track {
+        /* clean-css ignore:start */
         r: (@width[ @@size] - @track-stroke[ @@size]) / 2;
+        /* clean-css ignore:end */
         stroke-width: @track-stroke[ @@size];
     }
 
@@ -35,7 +37,9 @@
         @radius: (@width[ @@size] - @progress-stroke[ @@size]) / 2;
         @circumference: 2 * pi() * @radius;
 
+        /* clean-css ignore:start */
         r: @radius;
+        /* clean-css ignore:end */
         stroke-width: @progress-stroke[ @@size];
         stroke-dasharray: @circumference;
         stroke-dashoffset: calc(@circumference - var(--progress-percentage) * @circumference);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [X] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [X] Bugfix
-   [ ] Feature
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Other... Please describe:

## What is the current behavior?
Angular 9 uses [clean-css](https://github.com/clean-css/clean-css)@4.23 library during prod build of package.
This version of package has problem with single-character properties names ([issue#1021](https://github.com/clean-css/clean-css/issues/1021)).

To keep a CSS fragment intact (to ignore library's "cleaning") library's README recommends to use [special comment](https://github.com/clean-css/clean-css#how-to-keep-a-css-fragment-intact).

Closes #753

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
