### PR TITLE
ci: skip the branch which was deleted in the pull request from fork

### DIFF
--- a/.github/workflows/autorebase.yml
+++ b/.github/workflows/autorebase.yml
@@ -9,8 +9,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Autorebase
-              continue-on-error: true
-              uses: peter-evans/rebase@v1.0.5
+              uses: peter-evans/rebase@v1.0.6
               with:
                   token: ${{ secrets.GITHUB_TOKEN }}
                   base: main


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [ ] Feature
-   [ ] Refactoring (no functional changes, no api changes)
-   [x] Other... Please describe: ci

## What is the current behavior?

Closes #726

## What is the new behavior?

https://github.com/peter-evans/rebase/issues/86


```
@peter-evans

The reason it is null is because the head branch has been deleted in the pull request. See the PR here: TinkoffCreditSystems/taiga-ui#449

To fix it I've released a new version of the action to filter out pull requests where the head branch is not available anymore. Please retest with v1 or v1.0.6. I think it will be fixed now.
```

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No
