### PR TITLE
fix(core): `PrimitiveCalendar` red color for weekends (with custom `TUI_FIRST_DAY_OF_WEEK`)

### DIFF
--- a/projects/cdk/date-time/day.ts
+++ b/projects/cdk/date-time/day.ts
@@ -1,5 +1,5 @@
 import {tuiAssert} from '@taiga-ui/cdk/classes';
-import {TuiMonthNumber} from '@taiga-ui/cdk/enums';
+import {TuiDayOfWeek, TuiMonthNumber} from '@taiga-ui/cdk/enums';
 import {TuiDayLike} from '@taiga-ui/cdk/interfaces';
 import {padStart} from '@taiga-ui/cdk/utils/format';
 import {inRange, normalizeToIntNumber} from '@taiga-ui/cdk/utils/math';
@@ -26,6 +26,12 @@ export class TuiDay extends TuiMonth {
      */
     get formattedDay(): string {
         return `${this.formattedDayPart}.${this.formattedMonth}`;
+    }
+
+    get isWeekend(): boolean {
+        const dayOfWeek = this.dayOfWeek(false);
+
+        return dayOfWeek === TuiDayOfWeek.Saturday || dayOfWeek === TuiDayOfWeek.Sunday;
     }
 
     /**

--- a/projects/core/components/primitive-calendar/primitive-calendar.template.html
+++ b/projects/core/components/primitive-calendar/primitive-calendar.template.html
@@ -13,7 +13,7 @@
                     *ngIf="!itemIsUnavailable(item) || showAdjacent"
                     automation-id="tui-primitive-calendar__cell"
                     class="cell"
-                    [class.cell_weekend]="colIndex > 4"
+                    [class.cell_weekend]="item.isWeekend"
                     [class.cell_today]="itemIsToday(item)"
                     [class.cell_interval]="itemIsInterval(item)"
                     [attr.data-tui-element-range]="getItemRange(item)"

--- a/projects/core/components/primitive-calendar/test/primitive-calendar.component.spec.ts
+++ b/projects/core/components/primitive-calendar/test/primitive-calendar.component.spec.ts
@@ -303,6 +303,25 @@ describe('integration with TUI_FIRST_DAY_OF_WEEK token', () => {
         it('contains the fifth column with dates which are actual Thursday', () => {
             expect(getColumnDates(4)).toEqual(['3', '10', '17', '24', '1', '8']);
         });
+
+        it('sets red color only for weekends', () => {
+            expect(isAllWeekdays(getColumnCells(0))).toBe(
+                true,
+                'Sunday column should be red',
+            );
+
+            [1, 2, 3, 4, 5].forEach(index => {
+                expect(isAllWeekdays(getColumnCells(index))).toBe(
+                    false,
+                    'Monday-Friday should not be red',
+                );
+            });
+
+            expect(isAllWeekdays(getColumnCells(6))).toBe(
+                true,
+                'Saturday column should be red',
+            );
+        });
     });
 
     describe('Week starts with Monday if TUI_FIRST_DAY_OF_WEEK was set as TuiDayOfWeek.Monday', () => {
@@ -337,6 +356,25 @@ describe('integration with TUI_FIRST_DAY_OF_WEEK token', () => {
 
         it('contains the fifth column with dates which are actual Fridays', () => {
             expect(getColumnDates(4)).toEqual(['4', '11', '18', '25', '2', '9']);
+        });
+
+        it('sets red color only for weekends', () => {
+            [0, 1, 2, 3, 4].forEach(index => {
+                expect(isAllWeekdays(getColumnCells(index))).toBe(
+                    false,
+                    'Monday-Friday should not be red',
+                );
+            });
+
+            expect(isAllWeekdays(getColumnCells(5))).toBe(
+                true,
+                'Saturday column should be red',
+            );
+
+            expect(isAllWeekdays(getColumnCells(6))).toBe(
+                true,
+                'Sunday column should be red',
+            );
         });
     });
 
@@ -373,6 +411,25 @@ describe('integration with TUI_FIRST_DAY_OF_WEEK token', () => {
         it('contains the fifth column with dates which are actual Sundays', () => {
             expect(getColumnDates(4)).toEqual(['30', '6', '13', '20', '27', '4']);
         });
+
+        it('sets red color only for weekends', () => {
+            [0, 1, 2, 5, 6].forEach(index => {
+                expect(isAllWeekdays(getColumnCells(index))).toBe(
+                    false,
+                    'Monday-Friday should not be red',
+                );
+            });
+
+            expect(isAllWeekdays(getColumnCells(3))).toBe(
+                true,
+                'Saturday column should be red',
+            );
+
+            expect(isAllWeekdays(getColumnCells(4))).toBe(
+                true,
+                'Sunday column should be red',
+            );
+        });
     });
 
     function getDaysOfWeek(): string[] {
@@ -382,11 +439,20 @@ describe('integration with TUI_FIRST_DAY_OF_WEEK token', () => {
         return daysOfWeekContainers.map(container => container.nativeElement.textContent);
     }
 
-    function getColumnDates(columnIndex: number): string[] {
-        const columnDatesContainers =
+    function getColumnCells(columnIndex: number): DebugElement[] {
+        return (
             fixture.debugElement.queryAll(
                 By.css(`.row:not(.row_weekday) .cell:nth-child(${columnIndex + 1})`),
-            ) || [];
+            ) || []
+        );
+    }
+
+    function isAllWeekdays($cells: DebugElement[]): boolean {
+        return $cells.every(cell => cell.classes['cell_weekend']);
+    }
+
+    function getColumnDates(columnIndex: number): string[] {
+        const columnDatesContainers = getColumnCells(columnIndex);
 
         return columnDatesContainers.map(container =>
             container.nativeElement.textContent.trim(),


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [X] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
-   [X] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [X] Bugfix
-   [ ] Feature
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Other... Please describe:

## What is the current behavior?
```ts
{
  provide: TUI_FIRST_DAY_OF_WEEK,
  useValue: TuiDayOfWeek.Sunday,
}
```

<img width="369" alt="before" src="https://user-images.githubusercontent.com/35179038/135285378-acceb463-c66e-4055-90df-e1e1307a5750.png">

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

## What is the new behavior?
<img width="369" alt="after" src="https://user-images.githubusercontent.com/35179038/135285398-c945749b-ac07-4ac3-8bdf-fc769ea0cfec.png">


## Does this PR introduce a breaking change?

-   [ ] Yes
-   [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
