### PR TITLE
feat(addon-doc): support Promise content

### DIFF
--- a/projects/addon-doc/src/components/code/code.component.ts
+++ b/projects/addon-doc/src/components/code/code.component.ts
@@ -1,4 +1,8 @@
 import {Component, HostBinding, Input} from '@angular/core';
+import {BehaviorSubject} from 'rxjs';
+import {switchMap} from 'rxjs/operators';
+import {RawLoaderContent} from '../../interfaces/page';
+import {rawLoad} from '../../utils/raw-load';
 
 @Component({
     selector: 'tui-doc-code',
@@ -6,11 +10,17 @@ import {Component, HostBinding, Input} from '@angular/core';
     styleUrls: ['./code.style.less'],
 })
 export class TuiDocCodeComponent {
+    private readonly rawLoader$$ = new BehaviorSubject<RawLoaderContent>('');
+
+    readonly processor$ = this.rawLoader$$.pipe(switchMap(rawLoad));
+
     @Input()
     filename = '';
 
     @Input()
-    code = '';
+    set code(code: RawLoaderContent) {
+        this.rawLoader$$.next(code);
+    }
 
     @HostBinding('class._has-filename')
     get hasFilename(): boolean {

--- a/projects/addon-doc/src/components/code/code.template.html
+++ b/projects/addon-doc/src/components/code/code.template.html
@@ -1,2 +1,4 @@
-<p *ngIf="filename" class="t-header">{{ filename }}</p>
-<pre class="t-code"><code [lineNumbers]="true" [highlight]="code"></code></pre>
+<p *ngIf="filename" class="t-header">{{filename}}</p>
+<pre
+    class="t-code"
+><code [lineNumbers]="true" [highlight]="processor$ | async"></code></pre>

--- a/projects/addon-doc/src/components/example/example-get-tabs.pipe.ts
+++ b/projects/addon-doc/src/components/example/example-get-tabs.pipe.ts
@@ -1,0 +1,8 @@
+import {Pipe, PipeTransform} from '@angular/core';
+
+@Pipe({name: 'tuiDocExampleGetTabs'})
+export class TuiDocExampleGetTabsPipe implements PipeTransform {
+    public transform(content: Record<string, string>, defaultTab: string): string[] {
+        return [defaultTab, ...Object.keys(content)];
+    }
+}

--- a/projects/addon-doc/src/components/example/example.module.ts
+++ b/projects/addon-doc/src/components/example/example.module.ts
@@ -6,6 +6,7 @@ import {TuiTabsModule} from '@taiga-ui/kit';
 import {PolymorpheusModule} from '@tinkoff/ng-polymorpheus';
 import {TuiDocCodeModule} from '../code/code.module';
 import {TuiDocCopyModule} from '../copy/copy.module';
+import {TuiDocExampleGetTabsPipe} from './example-get-tabs.pipe';
 import {TuiDocExampleComponent} from './example.component';
 
 @NgModule({
@@ -18,7 +19,7 @@ import {TuiDocExampleComponent} from './example.component';
         TuiDocCodeModule,
         PolymorpheusModule,
     ],
-    declarations: [TuiDocExampleComponent],
-    exports: [TuiDocExampleComponent],
+    declarations: [TuiDocExampleComponent, TuiDocExampleGetTabsPipe],
+    exports: [TuiDocExampleComponent, TuiDocExampleGetTabsPipe],
 })
 export class TuiDocExampleModule {}

--- a/projects/addon-doc/src/components/example/example.template.html
+++ b/projects/addon-doc/src/components/example/example.template.html
@@ -18,41 +18,51 @@
     class="t-description"
     [content]="description"
 ></h4>
-<div class="t-example">
-    <div class="t-tabs-wrapper">
-        <tui-tabs-with-more
-            class="t-tabs"
-            [(activeItemIndex)]="activeItemIndex"
-        >
-            <ng-container *ngFor="let tab of tabs">
-                <button *tuiTab tuiTab>{{ tab }}</button>
-            </ng-container>
-        </tui-tabs-with-more>
 
-        <button
-            *ngIf="codeEditor"
-            tuiButton
-            appearance="flat"
-            size="s"
-            (click)="codeEditor.open(componentName, id || '', processedContent)"
-        >
-            Edit on {{ codeEditor.name }}
-        </button>
-    </div>
-    <ng-container [ngSwitch]="activeItem">
-        <div
-            *ngIf="isDefaultItem; else codeTab"
-            automation-id="tui-doc-example"
-            class="t-demo"
-        >
-            <ng-content></ng-content>
+<div *ngIf="processor$ | async as content" class="t-example">
+    <ng-container *ngIf="content | tuiDocExampleGetTabs: defaultTab as tabs">
+        <div class="t-tabs-wrapper">
+            <tui-tabs-with-more
+                class="t-tabs"
+                [(activeItemIndex)]="activeItemIndex"
+            >
+                <ng-container *ngFor="let tab of tabs">
+                    <button *tuiTab tuiTab>{{tab}}</button>
+                </ng-container>
+            </tui-tabs-with-more>
+
+            <button
+                *ngIf="codeEditor"
+                tuiButton
+                appearance="flat"
+                size="s"
+                (click)="codeEditor.open(componentName, id || '',  content)"
+            >
+                Edit on {{codeEditor.name}}
+            </button>
         </div>
-        <ng-template #codeTab>
-            <tui-doc-copy
-                class="t-copy-code"
-                [cdkCopyToClipboard]="code"
-            ></tui-doc-copy>
-            <tui-doc-code [code]="code"></tui-doc-code>
-        </ng-template>
+
+        <ng-container
+            *ngIf="{
+                activeTab: tabs[activeItemIndex],
+                code: content[tabs[activeItemIndex]] || ''
+            } as state"
+        >
+            <div
+                *ngIf="state.activeTab == defaultTab; else codeSection"
+                automation-id="tui-doc-example"
+                class="t-demo"
+            >
+                <ng-content></ng-content>
+            </div>
+
+            <ng-template #codeSection>
+                <tui-doc-copy
+                    class="t-copy-code"
+                    [cdkCopyToClipboard]="state.code"
+                ></tui-doc-copy>
+                <tui-doc-code [code]="state.code"></tui-doc-code>
+            </ng-template>
+        </ng-container>
     </ng-container>
 </div>

--- a/projects/addon-doc/src/interfaces/page.ts
+++ b/projects/addon-doc/src/interfaces/page.ts
@@ -11,3 +11,7 @@ export interface TuiDocPage extends TuiDocPageBase {
 export interface TuiDocPageGroup extends TuiDocPageBase {
     readonly subPages: ReadonlyArray<TuiDocPage>;
 }
+
+export type RawLoaderContent = Promise<{default: string}> | string;
+
+export type TuiDocExample = Record<string, RawLoaderContent>;

--- a/projects/addon-doc/src/tokens/example-content-processor.ts
+++ b/projects/addon-doc/src/tokens/example-content-processor.ts
@@ -1,8 +1,6 @@
 import {InjectionToken} from '@angular/core';
 import {identity, TuiHandler} from '@taiga-ui/cdk';
 
-export const TUI_DOC_EXAMPLE_CONTENT_PROCESSOR = new InjectionToken<
+export const TUI_DOC_EXAMPLE_CONTENT_PROCESSOR: InjectionToken<
     TuiHandler<Record<string, string>, Record<string, string>>
->('Processes content in example', {
-    factory: () => identity,
-});
+> = new InjectionToken('Processes content in example', {factory: () => identity});

--- a/projects/addon-doc/src/utils/raw-load-record.ts
+++ b/projects/addon-doc/src/utils/raw-load-record.ts
@@ -1,0 +1,14 @@
+import {TuiDocExample} from '../interfaces/page';
+import {rawLoad} from './raw-load';
+
+export async function rawLoadRecord(
+    example: TuiDocExample,
+): Promise<Record<string, string>> {
+    const processedContent: Record<string, string> = {};
+
+    for (const [key, content] of Object.entries(example)) {
+        processedContent[key] = await rawLoad(content);
+    }
+
+    return processedContent;
+}

--- a/projects/addon-doc/src/utils/raw-load.ts
+++ b/projects/addon-doc/src/utils/raw-load.ts
@@ -1,0 +1,5 @@
+import {RawLoaderContent} from '../interfaces/page';
+
+export async function rawLoad(content: RawLoaderContent): Promise<string> {
+    return content instanceof Promise ? (await content).default : content;
+}

--- a/projects/addon-doc/src/utils/test/raw-load-utils.spec.ts
+++ b/projects/addon-doc/src/utils/test/raw-load-utils.spec.ts
@@ -1,0 +1,25 @@
+import {rawLoad} from '../raw-load';
+import {rawLoadRecord} from '../raw-load-record';
+
+describe('tui-doc raw content utils', () => {
+    it('rawLoadRecord', async () => {
+        const result = await rawLoadRecord({
+            TypeScript: 'Hello',
+            HTML: Promise.resolve({default: 'World'}),
+        });
+
+        expect(result).toEqual({
+            TypeScript: 'Hello',
+            HTML: 'World',
+        });
+    });
+
+    it('rawLoad', async () => {
+        let result = await rawLoad('Hello');
+
+        expect(result).toBe('Hello');
+
+        result = await rawLoad(Promise.resolve({default: 'World'}));
+        expect(result).toBe('World');
+    });
+});

--- a/projects/demo/src/modules/app/stackblitz/stackblitz.service.ts
+++ b/projects/demo/src/modules/app/stackblitz/stackblitz.service.ts
@@ -9,7 +9,6 @@ import {default as tsconfig} from '!!raw-loader!./project-files/tsconfig.txt';
 import {Injectable} from '@angular/core';
 import stackblitz from '@stackblitz/sdk';
 import {CodeEditor} from '@taiga-ui/addon-doc';
-import {FrontEndExample} from '../../interfaces/front-end-example';
 import {TsFileComponentParser, TsFileModuleParser} from '../classes';
 import {STACKBLITZ_DEPS} from './stackblitz-deps.constants';
 import {
@@ -32,7 +31,7 @@ const APP_COMP_META = {
 export class StackblitzService implements CodeEditor {
     readonly name = 'Stackblitz';
 
-    open(component: string, sampleId: string, content: FrontEndExample) {
+    open(component: string, sampleId: string, content: Record<string, string>) {
         if (!content.HTML || !content.TypeScript) {
             return;
         }

--- a/projects/demo/src/modules/app/stackblitz/utils.ts
+++ b/projects/demo/src/modules/app/stackblitz/utils.ts
@@ -1,4 +1,4 @@
-import {FrontEndExample} from '../../interfaces/front-end-example';
+import {Project} from '@stackblitz/sdk/typings/interfaces';
 import {TsFileComponentParser, TsFileModuleParser, TsFileParser} from '../classes';
 import {isLess, isPrimaryComponentFile, isTS} from '../utils';
 
@@ -15,7 +15,7 @@ export const appPrefix = (stringsPart: TemplateStringsArray, path: string = '') 
 type FileName = string;
 type FileContent = string;
 
-export const getSupportFiles = <T extends FrontEndExample>(
+export const getSupportFiles = <T extends Record<string, string>>(
     files: T,
 ): Array<[FileName, FileContent]> => {
     return Object.entries(files).filter(
@@ -25,8 +25,8 @@ export const getSupportFiles = <T extends FrontEndExample>(
 
 export const prepareSupportFiles = (
     files: Array<[FileName, FileContent]>,
-): Record<FileName, FileContent> => {
-    const processedContent: Record<FileName, FileContent> = {};
+): Project['files'] => {
+    const processedContent: Project['files'] = {};
 
     for (const [fileName, fileContent] of files) {
         const prefixedFileName = appPrefix`${fileName}`;

--- a/projects/demo/src/modules/components/avatar/avatar.component.ts
+++ b/projects/demo/src/modules/components/avatar/avatar.component.ts
@@ -1,16 +1,7 @@
-import {default as example1Html} from '!!raw-loader!./examples/1/index.html';
-import {default as example1Ts} from '!!raw-loader!./examples/1/index.ts';
-
-import {default as example2Html} from '!!raw-loader!./examples/2/index.html';
-import {default as example2Ts} from '!!raw-loader!./examples/2/index.ts';
-
-import {default as exampleImportModule} from '!!raw-loader!./examples/import/import-module.txt';
-import {default as exampleInsertTemplate} from '!!raw-loader!./examples/import/insert-template.txt';
-
 import {Component} from '@angular/core';
+import {RawLoaderContent, TuiDocExample} from '@taiga-ui/addon-doc';
 import {TuiSizeXS, TuiSizeXXL} from '@taiga-ui/core';
 import {changeDetection} from '../../../change-detection-strategy';
-import {FrontEndExample} from '../../interfaces/front-end-example';
 
 @Component({
     selector: 'example-avatar',
@@ -18,17 +9,22 @@ import {FrontEndExample} from '../../interfaces/front-end-example';
     changeDetection,
 })
 export class ExampleTuiAvatarComponent {
-    readonly exampleImportModule = exampleImportModule;
-    readonly exampleInsertTemplate = exampleInsertTemplate;
+    readonly exampleImportModule: RawLoaderContent = import(
+        '!!raw-loader!./examples/import/import-module.txt'
+    );
 
-    readonly example1: FrontEndExample = {
-        TypeScript: example1Ts,
-        HTML: example1Html,
+    readonly exampleInsertTemplate: RawLoaderContent = import(
+        '!!raw-loader!./examples/import/insert-template.txt'
+    );
+
+    readonly example1: TuiDocExample = {
+        TypeScript: import('!!raw-loader!./examples/1/index.ts'),
+        HTML: import('!!raw-loader!./examples/1/index.html'),
     };
 
-    readonly example2: FrontEndExample = {
-        TypeScript: example2Ts,
-        HTML: example2Html,
+    readonly example2: TuiDocExample = {
+        TypeScript: import('!!raw-loader!./examples/2/index.ts'),
+        HTML: import('!!raw-loader!./examples/2/index.html'),
     };
 
     readonly avatarUrlVariants: readonly string[] = [


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

-   [ ] Bugfix
-   [x] Feature
-   [ ] Refactoring (no functional changes, no api changes)
-   [ ] Other... Please describe:

## What is the current behavior?

```ts
import {default as example1Html} from '!!raw-loader!./examples/1/index.html';
import {default as example1Ts} from '!!raw-loader!./examples/1/index.ts';

import {default as example2Html} from '!!raw-loader!./examples/2/index.html';
import {default as example2Ts} from '!!raw-loader!./examples/2/index.ts';

import {default as exampleImportModule} from '!!raw-loader!./examples/import/import-module.txt';
import {default as exampleInsertTemplate} from '!!raw-loader!./examples/import/insert-template.txt';

//
export class ExampleTuiAvatarComponent {
    readonly exampleImportModule = exampleImportModule;
    readonly exampleInsertTemplate = exampleInsertTemplate;

    readonly example1: FrontEndExample = {
        TypeScript: example1Ts,
        HTML: example1Html,
    };

    readonly example2: FrontEndExample = {
        TypeScript: example2Ts,
        HTML: example2Html,
    };
}
```

in the current codebase you need to come up with names for the variables for the source files

## What is the new behavior?

```ts
export class ExampleTuiAvatarComponent {
    readonly exampleImportModule = import('!!raw-loader!./examples/import/import-module.txt');
    readonly exampleInsertTemplate = import('!!raw-loader!./examples/import/insert-template.txt');

    readonly example1: TuiDocExample = {
        TypeScript: import('!!raw-loader!./examples/1/index.ts'),
        HTML: import('!!raw-loader!./examples/1/index.html'),
    };

    readonly example2: TuiDocExample = {
        TypeScript: import('!!raw-loader!./examples/2/index.ts'),
        HTML: import('!!raw-loader!./examples/2/index.html'),
    };
```

you can assign imports directly

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No

