### PR TITLE
refactor(core): use html whitespace instead shifted value

### DIFF
--- a/projects/core/components/primitive-textfield/primitive-textfield.component.ts
+++ b/projects/core/components/primitive-textfield/primitive-textfield.component.ts
@@ -251,7 +251,7 @@ export class TuiPrimitiveTextfieldComponent
     get computedFiller(): string {
         return this.hasExampleText
             ? this.controller.exampleText
-            : this.filler.slice(this.value.length);
+            : this.filler?.toString().slice(this.value?.toString().length);
     }
 
     // Safari expiration date autofill workaround

--- a/projects/core/components/primitive-textfield/primitive-textfield.template.html
+++ b/projects/core/components/primitive-textfield/primitive-textfield.template.html
@@ -82,16 +82,20 @@
                 aria-hidden="true"
             >
                 <span class="value-decoration-inner">
-                    <span class="ghost">{{value}}</span>
-                    <span automation-id="tui-primitive-textfield__example-text"
-                        >{{computedFiller}}</span
+                    <span class="ghost" *ngIf="value">{{value}}</span>
+                    <span
+                        *ngIf="computedFiller as fillerValue"
+                        automation-id="tui-primitive-textfield__example-text"
                     >
+                        {{fillerValue}}
+                    </span>
                     <span
                         *ngIf="hasPostfix"
                         class="postfix"
                         [class.postfix_shifted]="postfixShifted"
-                        >{{postfix}}</span
                     >
+                        {{postfix}}
+                    </span>
                 </span>
             </div>
         </div>

--- a/projects/core/components/primitive-textfield/test/primitive-textfield.component.spec.ts
+++ b/projects/core/components/primitive-textfield/test/primitive-textfield.component.spec.ts
@@ -108,7 +108,7 @@ describe('PrimitiveTextfield', () => {
             testComponent.size = 'l';
         });
 
-        it('is not swown when value is empty and field is not focused', () => {
+        it('is not shown when value is empty and field is not focused', () => {
             const example = 'text';
             const postfix = 'post';
 
@@ -133,12 +133,14 @@ describe('PrimitiveTextfield', () => {
 
             fixture.detectChanges();
 
-            expect(getValueDecoration()!.nativeElement.textContent.trim()).toBe(
-                value + filler.slice(value.length) + postfix,
+            const processedFiller = filler.slice(value.length);
+
+            expect(getHtmlDecoration()).toBe(
+                `<span><span>${value}</span><span> ${processedFiller} </span><span> ${postfix} </span></span>`,
             );
         });
 
-        it('value and postfix are shpwn when value is not empty', () => {
+        it('value and postfix are shown when value is not empty', () => {
             const value = 'value';
             const postfix = 'post';
 
@@ -147,8 +149,8 @@ describe('PrimitiveTextfield', () => {
 
             fixture.detectChanges();
 
-            expect(getValueDecoration()!.nativeElement.textContent.trim()).toBe(
-                value + postfix,
+            expect(getHtmlDecoration()).toBe(
+                `<span><span>${value}</span><span> ${postfix} </span></span>`,
             );
         });
     });
@@ -163,5 +165,13 @@ describe('PrimitiveTextfield', () => {
 
     function getValueDecoration(): DebugElement | null {
         return pageObject.getByAutomationId('tui-primitive-textfield__value-decoration');
+    }
+
+    function getHtmlDecoration(): string {
+        return (
+            getValueDecoration()
+                ?.nativeElement.innerHTML.replace(/<(\w+)(.|[\r\n])*?>/gs, '<$1>')
+                .replace(/<!--.*?-->/gs, '') ?? ''
+        );
     }
 });

--- a/projects/core/styles/mixins/textfield.less
+++ b/projects/core/styles/mixins/textfield.less
@@ -277,10 +277,6 @@
         .transition(~'color');
         color: var(--tui-text-01);
 
-        &_shifted {
-            margin-left: 0.5ch;
-        }
-
         :host[data-mode='onDark'] & {
             color: var(--tui-text-01-night);
         }

--- a/projects/core/styles/mixins/textfield.scss
+++ b/projects/core/styles/mixins/textfield.scss
@@ -271,10 +271,6 @@
         @include transition('color');
         color: var(--tui-text-01);
 
-        &_shifted {
-            margin-left: 0.5ch;
-        }
-
         :host[data-mode='onDark'] & {
             color: var(--tui-text-01-night);
         }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [ ] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

-   [ ] Bugfix
-   [ ] Feature
-   [x] Refactoring
-   [ ] Code style update
-   [ ] Build or CI related changes
-   [ ] Documentation content changes

## What is the current behavior?

Need changes before upgrade to https://github.com/TinkoffCreditSystems/taiga-ui/pull/988

## What is the new behavior?

- with value and with filler and with postfix

![image](https://user-images.githubusercontent.com/12021443/141303110-ca66e91c-5bbd-4c6f-b869-15a71245bc59.png)

- without value and with filler and with postfix

![image](https://user-images.githubusercontent.com/12021443/141303141-5e4c960f-24e2-4e7b-808a-36b1c53931ca.png)

- without value and without filler and with postfix

![image](https://user-images.githubusercontent.com/12021443/141303268-4fadc2b2-6460-4ff8-83d6-68939d6525f2.png)

- with value and without filler and with postfix

![image](https://user-images.githubusercontent.com/12021443/141303448-55ed31a0-271b-4351-b8d8-823fab3d0833.png)


## Does this PR introduce a breaking change?

-   [ ] Yes
-   [x] No
