### PR TITLE
fix(core): remove input-inline expression change error

### DIFF
--- a/projects/kit/components/input-inline/input-inline.component.ts
+++ b/projects/kit/components/input-inline/input-inline.component.ts
@@ -70,7 +70,7 @@ export class TuiInputInlineComponent
 
     @HostBinding('attr.data-value')
     get maskedValue(): string {
-        return this.native && this.value
+        return this.native?.nativeElement.value && this.value
             ? this.native.nativeElement.value
             : String(this.value);
     }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

-   [X] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
-   [ ] Tests for the changes have been added (for bug fixes / features)
-   [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

-   [X] Bugfix
-   [ ] Feature
-   [ ] Refactoring
-   [ ] Code style update
-   [ ] Build or CI related changes
-   [ ] Documentation content changes

## What is the current behavior?

Closes https://github.com/TinkoffCreditSystems/taiga-ui/issues/490

## What is the new behavior?
When using change detection default strategy, input-inline is not firing the expression after change error in console.

## Does this PR introduce a breaking change?

-   [ ] Yes
-   [X] No
