### PR TITLE
fix(addon-doc): vertical scrollbar height for root content

### DIFF
--- a/projects/addon-doc/src/components/main/main.style.less
+++ b/projects/addon-doc/src/components/main/main.style.less
@@ -7,7 +7,7 @@ html {
     height: auto;
 }
 
-tui-root > tui-scroll-controls {
+tui-root > tui-scroll-controls > .bar_vertical {
     top: @sticky-header-height !important;
 }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

In case when main content area has an overflow and a vertical scrollbar appears, in the lowest position thumb goes beyond the bottom edge of the viewport.

## What is the new behavior?

Bottom edge of the thumb stops exactly at the bottom edge of the viewport.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
